### PR TITLE
shopAPI > auth > Authentication, Captcha API 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "axios": "^0.27.2",
         "dayjs": "^1.11.1",
         "react": "^18.1.0",
+        "react-device-detect": "^2.2.2",
         "react-dom": "^18.1.0",
         "react-helmet-async": "^1.3.0",
         "react-scripts": "5.0.1",

--- a/src/api/auth/authentication.ts
+++ b/src/api/auth/authentication.ts
@@ -1,0 +1,291 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+import { getPlatform } from 'utils';
+
+export enum AUTH_TYPE {
+    SMS = 'SMS',
+    EMAIL = 'EMAIL',
+}
+
+export enum CERTIFICATED_USAGE {
+    FIND_ID = 'FIND_ID',
+    FIND_PASSWORD = 'FIND_PASSWORD',
+    CHANGE_MOBILE_NO = 'CHANGE_MOBILE_NO',
+    RELEASE_DORMANT = 'RELEASE_DORMANT',
+    ADMIN = 'ADMIN',
+    JOIN = 'JOIN',
+    JOIN_URI = 'JOIN_URI',
+    CHANGE_ID = 'CHANGE_ID',
+    ADMIN_SECONDARY = 'ADMIN_SECONDARY',
+    CHANGE_EMAIL = 'CHANGE_EMAIL',
+}
+
+export enum PLATFORM_TYPE {
+    PC = 'PC',
+    MOBILE_WEB = 'MOBILE_WEB',
+    AOS = 'AOS',
+    IOS = 'IOS',
+}
+
+export enum OPEN_ID_PROVIDER {
+    NCP_NAVER = 'ncp_naver',
+    NCP_KAKAO = 'ncp_kakao',
+    NCP_LINE = 'ncp_line',
+    NCP_FACEBOOK = 'ncp_facebook',
+    NCP_PAYCO = 'ncp_payco',
+}
+
+interface CertificatedNumber {
+    type: AUTH_TYPE;
+    usage: CERTIFICATED_USAGE;
+    certificatedNumber: String;
+    memberNo?: Nullable<Number>;
+    notiAccount?: Nullable<String>;
+    memberName: Nullable<String>;
+}
+
+interface CheckBizmallBody {
+    companyNo: Number;
+    name: String;
+    idNo: String;
+}
+
+interface CertificatedNumberViaEmail<T> {
+    usage: T;
+    email: String;
+    certificatedNumber: String;
+    memberName: Nullable<String>;
+    uri: Nullable<String>;
+}
+
+interface CertificatedNumberViaSMS<T> {
+    usage: T;
+    mobileNo: String;
+    key: String;
+    memberName: String;
+}
+
+interface OpenIdAccessToken {
+    provider: OPEN_ID_PROVIDER;
+    code: String;
+    openAccessToken: String;
+    redirectUri: String;
+    state: String;
+    platformType: PLATFORM_TYPE;
+}
+
+interface AccessTokenBody {
+    memberId: String;
+    password: String;
+    keepLogin: Boolean;
+    captcha?: String;
+    provider?: Nullable<String>;
+}
+
+const authentication = {
+    checkCertificatedNumber: ({
+        type,
+        usage,
+        certificatedNumber,
+        memberNo,
+        notiAccount,
+    }: Omit<CertificatedNumber, 'memberName'>): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/authentications',
+            data: {
+                type,
+                usage,
+                certificatedNumber,
+                memberNo,
+                notiAccount,
+            },
+        }),
+
+    sendCertificatedNumber: ({
+        type,
+        usage,
+        memberNo,
+        notiAccount,
+        memberName,
+    }: Omit<
+        CertificatedNumber,
+        'certificatedNumber'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/authentications',
+            data: {
+                type,
+                usage,
+                memberNo,
+                notiAccount,
+                memberName,
+            },
+        }),
+
+    checkBizmallAuth: ({
+        companyNo,
+        name,
+        idNo,
+    }: CheckBizmallBody): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/authentications/bizmall',
+            data: { companyNo, name, idNo },
+        }),
+
+    checkCertificatedNumberViaEmail: ({
+        usage,
+        email,
+        certificatedNumber,
+    }: Omit<
+        CertificatedNumberViaEmail<
+            Omit<
+                CERTIFICATED_USAGE,
+                | 'CHANGE_MOBILE_NO'
+                | 'ADMIN'
+                | 'JOIN'
+                | 'CHANGE_ID'
+                | 'ADMIN_SECONDARY'
+                | 'CHANGE_EMAIL'
+            >
+        >,
+        'memberName' | 'uri'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/authentications/email',
+            data: {
+                usage,
+                email,
+                certificatedNumber,
+            },
+        }),
+
+    sendCertificatedNumberViaEmail: ({
+        usage,
+        email,
+        memberName,
+        uri,
+    }: Omit<
+        CertificatedNumberViaEmail<CERTIFICATED_USAGE>,
+        'certificatedNumber'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/authentications/email',
+            data: { usage, email, memberName, uri },
+        }),
+
+    checkCertificatedNumberViaSMS: ({
+        usage,
+        mobileNo,
+        key,
+    }: Omit<
+        CertificatedNumberViaSMS<
+            Omit<
+                CERTIFICATED_USAGE,
+                | 'ADMIN'
+                | 'JOIN_URI'
+                | 'CHANGE_ID'
+                | 'ADMIN_SECONDARY'
+                | 'CHANGE_EMAIL'
+            >
+        >,
+        'memberName'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/authentications/sms',
+            data: { usage, mobileNo, key },
+        }),
+
+    sendCertificatedNumberViaSMS: ({
+        usage,
+        mobileNo,
+        memberName,
+    }: Omit<
+        CertificatedNumberViaSMS<CERTIFICATED_USAGE>,
+        'key'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/authentications/sms',
+            data: {
+                usage,
+                mobileNo,
+                memberName,
+            },
+        }),
+
+    checkOpenIdLoginUrl: ({
+        provider,
+        redirectUri,
+        state,
+    }: Pick<
+        OpenIdAccessToken,
+        'provider' | 'redirectUri' | 'state'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/oauth/login-url',
+            data: { provider, redirectUri, state },
+        }),
+
+    issueOpenIdAccessToken: ({
+        provider,
+        code,
+        openAccessToken,
+        redirectUri,
+        state,
+        platformType = getPlatform(),
+    }: OpenIdAccessToken): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/oauth/openid',
+            data: {
+                provider,
+                code,
+                openAccessToken,
+                redirectUri,
+                state,
+                platformType,
+            },
+        }),
+
+    getAccessToken: ({
+        memberId,
+        password,
+        keepLogin = false,
+        provider,
+    }: AccessTokenBody): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/oauth/token',
+            data: { memberId, password, keepLogin, provider },
+        }),
+
+    deleteAccessToken: (): Promise<AxiosResponse> => {
+        return request({
+            method: 'DELETE',
+            url: '/oauth/token',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        });
+    },
+
+    getOpenIdAccessToken: (): Promise<AxiosResponse> => {
+        return request({
+            method: 'GET',
+            url: '/openid/token',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        });
+    },
+};
+
+export default authentication;

--- a/src/api/auth/captcha.ts
+++ b/src/api/auth/captcha.ts
@@ -1,0 +1,25 @@
+import { AxiosResponse } from 'axios';
+
+import request from 'api/core';
+
+interface CaptchaImageBody {
+    code: String;
+    key: String;
+}
+
+const captcha = {
+    generateCaptchaImage: ({ key }: { key: string }): Promise<AxiosResponse> =>
+        request({ url: '/captcha/image', data: { key } }),
+
+    checkCaptchaImage: ({
+        code,
+        key,
+    }: CaptchaImageBody): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/captcha/verify',
+            data: { code, key },
+        }),
+};
+
+export default captcha;

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,0 +1,4 @@
+import authentication from 'api/auth/authentication';
+import captcha from 'api/auth/captcha';
+
+export { authentication, captcha };

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,20 +1,32 @@
 import axios, { AxiosInstance } from 'axios';
 
-// Axios Instance: https://pinokio0702.tistory.com/373 참고
-const request: AxiosInstance = axios.create({
-    baseURL: process.env.REACT_APP_BASE_URL,
-    headers: {
+import { getPlatform } from 'utils';
+
+export const defaultHeaders = () => {
+    return {
         version: process.env.REACT_APP_VERSION || '',
         clientId: process.env.REACT_APP_CLIENT_ID || '',
-        platform: 'PC',
-    },
+        platform: getPlatform(),
+    };
+};
+
+const request: AxiosInstance = axios.create({
+    baseURL: process.env.REACT_APP_BASE_URL,
+    headers: defaultHeaders(),
 });
 
 // 요청 타임아웃 설정
 request.defaults.timeout = 2500;
+
 // 요청 인터셉터 추가
-request.interceptors.request.use();
+request.interceptors.request.use((config) => {
+    return config;
+});
+
 // 응답 인터셉터 추가
-request.interceptors.response.use();
+request.interceptors.response.use((res) => {
+    // TODO: 토큰이 만료됐을 경우 처리 필요
+    return res;
+});
 
 export default request;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="react-scripts" />
+
+type Nullable<T> = T | null;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,20 @@
+import { deviceDetect } from 'react-device-detect';
+
+import { PLATFORM_TYPE } from 'api/auth/authentication';
+
+const getPlatform = (): PLATFORM_TYPE => {
+    const device = deviceDetect(navigator.userAgent);
+    if (device.isMobile) {
+        if (device.os === 'iOS') {
+            return PLATFORM_TYPE.IOS;
+        }
+        if (device.os === 'android') {
+            return PLATFORM_TYPE.AOS;
+        }
+    }
+
+    // TODO: PC인지 모바일 웹인지 확인 필요
+    return PLATFORM_TYPE.PC;
+};
+
+export { getPlatform };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7206,6 +7206,13 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+react-device-detect@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.2.2.tgz#dbabbce798ec359c83f574c3edb24cf1cca641a5"
+  integrity sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==
+  dependencies:
+    ua-parser-js "^1.0.2"
+
 react-dom@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
@@ -8375,6 +8382,11 @@ typescript@^4.6.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+ua-parser-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
+  integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
 
 unbox-primitive@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
-   인증번호 확인하기(checkCertificatedNumber)
-   인증번호 발송하기(sendCertificatedNumber)
-   비즈몰 가입 권한 확인하기(checkBizmallAuth)
-   이메일로 전달받은 인증코드 확인하기(checkCertificatedNumberViaEmail)
-   SMS로 전달받은 인증코드 확인하기(sendCertificatedNumberViaEmail)
-   휴대폰 점유 인증을 위해 인증코드(6자리) SMS 발송하기(checkCertificatedNumberViaSMS)
-   OpenId 로그인 url 조회하기(sendCertificatedNumberViaSMS)
-   OpenId AccessToken 발급하기(checkOpenIdLoginUrl)
-   AccessToken 발급하기(issueOpenIdAccessToken)
-   AccessToken 반환하기(getAccessToken)
-   AccessToken 조회하기(getOpenIdAccessToken)
-   캡챠 이미지 생성하기(generateCaptchaImage)
-   캡챠 인증코드 확인하기(checkCaptchaImage)
