### PR TITLE
shopAPI > display > Review API 추가

### DIFF
--- a/src/api/display/banner.ts
+++ b/src/api/display/banner.ts
@@ -1,34 +1,42 @@
 import { AxiosResponse } from 'axios';
 
-import request from 'api/core';
+import request, { defaultHeaders } from 'api/core';
 
 const banner = {
     getBanners: (bannerSectionCodes: Array<String>): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: `/display/banners/${bannerSectionCodes}`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
         }),
-    // 샵바이 프로 전용
-    getSkinBanners: (
-        skinCode: String,
-        bannerGroupCodes: String,
-    ): Promise<AxiosResponse> =>
+
+    getSkinBanners: ({
+        skinCode,
+        bannerGroupCodes,
+    }: {
+        skinCode: String;
+        bannerGroupCodes: String;
+    }): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/display/skin-banners',
-            data: {
+            params: {
                 skinCode,
                 bannerGroupCodes,
             },
         }),
-    // 샵바이 프로 전용
-    getBannerGroupBySkin: (
-        isPreview: Boolean = false,
-    ): Promise<AxiosResponse> =>
+
+    getBannerGroupBySkin: ({
+        isPreview = false,
+    }: {
+        isPreview: Boolean;
+    }): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: 'skin-banners/groups-by-skin',
-            data: {
+            params: {
                 isPreview,
             },
         }),

--- a/src/api/display/category.ts
+++ b/src/api/display/category.ts
@@ -3,21 +3,22 @@ import { AxiosResponse } from 'axios';
 import request from 'api/core';
 
 const category = {
-    getCategories: (keyword: String): Promise<AxiosResponse> =>
+    getCategories: ({ keyword }: { keyword: String }): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/categories',
-            data: {
+            params: {
                 keyword,
             },
         }),
+
     getNewProductCategories: (): Promise<AxiosResponse> =>
         request({ method: 'GET', url: '/categories/new-product-categories' }),
+
     getCategory: (categoryNo: String): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: `/categories/${categoryNo}`,
-            data: { categoryNo },
         }),
 };
 

--- a/src/api/display/index.ts
+++ b/src/api/display/index.ts
@@ -1,4 +1,5 @@
 import banner from 'api/display/banner';
 import category from 'api/display/category';
+import review from 'api/display/review';
 
-export { banner, category };
+export { banner, category, review };

--- a/src/api/display/review.ts
+++ b/src/api/display/review.ts
@@ -1,0 +1,346 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+
+export enum BEST_REVIEW_YN {
+    Y, // 우수 상품평
+    N, // 일반 상품평
+    NULL, // 전체
+}
+
+export enum MY_REVIEW_YN {
+    Y, // 내 상품평
+    N, // 전체 상품평
+}
+
+export enum HAS_ATTACHMENT_FILE {
+    Y, // 파일 첨부
+    N, // 파일 미첨부
+    ALL, // 빈값
+}
+
+export enum REPORT_REASON_CODE {
+    COPYRIGHT = 'COPYRIGHT',
+    SLANDER = 'SLANDER',
+}
+
+export enum SEARCH_TYPE {
+    CONTENT = 'CONTENT',
+    PRODUCT_NAME = 'PRODUCT_NAME',
+    ALL = 'ALL',
+}
+
+interface CategoryProductReviewsParams {
+    hasAttachmentFile: Boolean;
+    categoryDepth: Number;
+    categoryNo: Number;
+    productName: String;
+    brandName: String;
+    bestReviewYn: BEST_REVIEW_YN;
+    myReviewYn: MY_REVIEW_YN;
+}
+
+interface ProductReviewsParams {
+    hasAttachmentFile: HAS_ATTACHMENT_FILE;
+    bestReviewYn: BEST_REVIEW_YN;
+}
+
+interface ProductReviewBody {
+    optionNo: Number;
+    orderOptionNo: Number;
+    content: String;
+    rate: Number;
+    urls: String[];
+    extraJson: String;
+}
+
+interface ReportProductReviewBody {
+    reportReasonCd: REPORT_REASON_CODE;
+    content: String;
+}
+
+interface MyProductReviewsParams {
+    startYmd: String;
+    endYmd: String;
+    bestReviewYn: BEST_REVIEW_YN;
+    searchType: SEARCH_TYPE;
+    searchKeyword: String;
+}
+
+interface MyAvailableReviewsParams {
+    startDate: String;
+    endDate: String;
+    productName: String;
+    productNo: Number;
+    orderNo: String;
+}
+
+const review = {
+    getCategoryProductReviews: ({
+        hasAttachmentFile,
+        categoryDepth,
+        categoryNo,
+        productName,
+        orderBy,
+        orderDirection = ORDER_DIRECTION.DESC,
+        brandName,
+        bestReviewYn,
+        myReviewYn = MY_REVIEW_YN.N,
+        pageNumber = 1,
+        pageSize = 20,
+        hasTotalCount = false,
+    }: CategoryProductReviewsParams & Paging & Sort): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/category/product-reviews',
+            params: {
+                hasAttachmentFile,
+                categoryDepth,
+                categoryNo,
+                productName,
+                'order.by': orderBy,
+                'order.direction': orderDirection,
+                brandName,
+                bestReviewYn,
+                myReviewYn,
+                pageNumber,
+                pageSize,
+                hasTotalCount,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    getReviewBoardConfig: (): Promise<AxiosResponse> =>
+        request({ method: 'GET', url: '/product-reviews/configurations' }),
+
+    getProductReviews: (
+        productNo: String,
+        {
+            hasAttachmentFile = HAS_ATTACHMENT_FILE.N,
+            orderBy,
+            orderDirection = ORDER_DIRECTION.DESC,
+            bestReviewYn,
+            pageNumber = 1,
+            pageSize = 10,
+            hasTotalCount = false,
+        }: ProductReviewsParams & Paging & Sort,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/products/${productNo}/product-reviews`,
+            params: {
+                hasAttachmentFile,
+                'order.by': orderBy,
+                'order.direction': orderDirection,
+                bestReviewYn,
+                pageNumber,
+                pageSize,
+                hasTotalCount,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    registerProductReview: (
+        productNo: String,
+        {
+            optionNo,
+            orderOptionNo,
+            content,
+            rate,
+            urls,
+            extraJson,
+        }: ProductReviewBody,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/products/${productNo}/product-reviews`,
+            data: {
+                optionNo,
+                orderOptionNo,
+                content,
+                rate,
+                urls,
+                extraJson,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    getReviewableOptions: (
+        productNo: String,
+        { orderNo }: { orderNo: String },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/products/${productNo}/reviewable-options`,
+            params: { orderNo },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    getProductReview: (
+        productNo: String,
+        reviewNo: String,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/products/${productNo}/product-reviews/${reviewNo}`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    updateProductReview: (
+        productNo: String,
+        reviewNo: String,
+        {
+            urls,
+            rate,
+            content,
+        }: Omit<ProductReviewBody, 'optionNo' | 'orderOptionNo' | 'extraJson'>,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/products/${productNo}/product-reviews/${reviewNo}`,
+            data: {
+                urls,
+                rate,
+                content,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    deleteProductReview: (
+        productNo: String,
+        reviewNo: String,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'DELETE',
+            url: `/products/${productNo}/product-reviews/${reviewNo}`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    getProductReviewComments: (
+        productNo: String,
+        reviewNo: String,
+        { hasTotalCount = false, pageNumber = 1, pageSize = 10 }: Paging,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/products/${productNo}/product-reviews/${reviewNo}/comments`,
+            params: {
+                hasTotalCount,
+                page: pageNumber,
+                size: pageSize,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    recommendProductReview: (
+        productNo: String,
+        reviewNo: String,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/products/${productNo}/product-reviews/${reviewNo}/recommend`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    cancelProductReviewRecommend: (
+        productNo: String,
+        reviewNo: String,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'DELETE',
+            url: `/products/${productNo}/product-reviews/${reviewNo}/recommend`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    reportProductReview: (
+        productNo: String,
+        reviewNo: String,
+        { reportReasonCd, content }: ReportProductReviewBody,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/products/${productNo}/product-reviews/${reviewNo}/report`,
+            data: { reviewNo, reportReasonCd, content },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    getMyProductReviews: ({
+        pageNumber,
+        pageSize,
+        hasTotalCount = false,
+        startYmd,
+        endYmd,
+        bestReviewYn,
+        searchType,
+        searchKeyword,
+    }: MyProductReviewsParams & Paging): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/product-reviews',
+            params: {
+                pageNumber,
+                pageSize,
+                hasTotalCount,
+                startYmd,
+                endYmd,
+                bestReviewYn,
+                searchType,
+                searchKeyword,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+
+    getMyAvailableReviews: ({
+        pageNumber = 1,
+        pageSize,
+        hasTotalCount = false,
+        startDate,
+        endDate,
+        productName,
+        productNo,
+        orderNo,
+    }: MyAvailableReviewsParams & Paging): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/order-options/product-reviewable',
+            data: {
+                pageNumber,
+                pageSize,
+                hasTotalCount,
+                startDate,
+                endDate,
+                productName,
+                productNo,
+                orderNo,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: JSON.parse(localStorage.accessToken).accessToken,
+            }),
+        }),
+};
+
+export default review;

--- a/src/api/display/review.ts
+++ b/src/api/display/review.ts
@@ -67,7 +67,7 @@ interface MyProductReviewsParams {
     searchKeyword: String;
 }
 
-interface MyAvailableReviewsParams {
+interface MyReviewableProductsParams {
     startDate: String;
     endDate: String;
     productName: String;
@@ -314,7 +314,7 @@ const review = {
             }),
         }),
 
-    getMyAvailableReviews: ({
+    getMyReviewableProducts: ({
         pageNumber = 1,
         pageSize,
         hasTotalCount = false,
@@ -323,11 +323,11 @@ const review = {
         productName,
         productNo,
         orderNo,
-    }: MyAvailableReviewsParams & Paging): Promise<AxiosResponse> =>
+    }: MyReviewableProductsParams & Paging): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/profile/order-options/product-reviewable',
-            data: {
+            params: {
                 pageNumber,
                 pageSize,
                 hasTotalCount,

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,3 +1,26 @@
 /// <reference types="react-scripts" />
 
 type Nullable<T> = T | null;
+
+interface Paging {
+    pageNumber: Number;
+    pageSize: Number;
+    hasTotalCount: Boolean;
+}
+
+enum ORDER_DIRECTION {
+    ASC = 'ASC',
+    DESC = 'DESC',
+}
+
+enum ORDER_BY {
+    RECOMMEND = 'RECOMMEND',
+    REGISTER_YMDT = 'REGISTER_YMDT',
+    RATING = 'RATING',
+    BEST_REVIEW = 'BEST_REVIEW',
+}
+
+interface Sort {
+    orderBy: ORDER_BY;
+    orderDirection: ORDER_DIRECTION;
+}


### PR DESCRIPTION
-   카테고리 상품평 목록 조회하기(getCategoryProductReviews)
-   [샵바이프로 전용] 상품평 게시판 설정 조회하기(getReviewBoardConfig)
-   상품평 목록 조회하기(getProductReviews)
-   상품평 등록하기(registerProductReview)
-   상품평 가능 유무 조회하기(getReviewableOptions)
-   상품평 가져오기(getProductReview)
-   상품평 수정하기(updateProductReview)
-   상품평 삭제하기(deleteProductReview)
-   상품평의 댓글 목록 조회하기(getProductReviewComments)
-   상품평 추천하기(recommendProductReview)
-   상품평 추천 취소하기(cancelProductReviewRecommend)
-   상품평 신고하기(reportProductReview)
-   내 상품평 목록 조회하기(getMyProductReviews)
-   내 상품평 작성 가능 목록 조회하기(getMyAvailableReviews)
