### PR TITLE
shopAPI > order > GuestOrder, OrderConfiguration API  작성

### DIFF
--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -1,7 +1,6 @@
 import { AxiosResponse } from 'axios';
 
-import request from 'api/core';
-import { defaultHeaders } from 'api/core';
+import request, { defaultHeaders } from 'api/core';
 import {
     ShoppingCartBody,
     TokenIssueBody,
@@ -104,7 +103,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
-    getOrderCancelDetail: (
+    getNonMemberOrderDetail: (
         orderNo: String,
         {
             orderRequestType,
@@ -155,7 +154,7 @@ const guestOrder = {
         }),
 
     // TODO orderNo 모름, 400 error 발생 추후 테스트 필요
-    getPasswordByEmail: (
+    sendPasswordByEmail: (
         orderNo: String,
         { replyType, mobileNo, email, name }: PasswordParams,
     ): Promise<AxiosResponse> =>

--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -1,0 +1,162 @@
+import { AxiosResponse } from 'axios';
+
+import request from 'api/core';
+import {
+    ShoppingCartBody,
+    TokenIssueBody,
+    ReceiptBody,
+    GuestToken,
+    DeliveryBody,
+    PasswordParams,
+    ORDER_REQUEST_TYPE,
+    CLAIM_TYPE,
+} from 'api/order/types';
+
+const guestOrder = {
+    // TODO parameter 모름 400, 404 error 발생 추후 테스트 필요
+    getShoppingCart: (
+        {
+            orderCnt,
+            channelType,
+            optionInputs,
+            optionNo,
+            productNo,
+            cartNo,
+        }: ShoppingCartBody,
+        { divideInvalidProducts }: { divideInvalidProducts?: Boolean },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/guest/cart',
+            data: [
+                {
+                    divideInvalidProducts,
+                    orderCnt,
+                    channelType,
+                    optionInputs,
+                    optionNo,
+                    productNo,
+                    cartNo,
+                },
+            ],
+        }),
+
+    orderDetail: (
+        orderNo: String,
+        { orderRequestType }: { orderRequestType?: ORDER_REQUEST_TYPE },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/guest/orders/${orderNo}`,
+            params: { orderRequestType },
+        }),
+
+    // TODO orderNo 모름, 404 error 발생 추후 테스트 필요
+    issueOrderToken: (
+        orderNo: String,
+        { password, name, mobileNo, email, orderRequestType }: TokenIssueBody,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/guest/orders/${orderNo}`,
+            data: { password, name, mobileNo, email, orderRequestType },
+        }),
+
+    // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
+    purchaseConfirm: (
+        orderOptionNo: String,
+        { guestToken }: GuestToken,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/guest/order-options/${orderOptionNo}/confirm`,
+            data: { guestToken },
+        }),
+
+    // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
+    deliveryCompleted: (
+        orderOptionNo: String,
+        { guestToken }: GuestToken,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/guest/order-options/${orderOptionNo}/delivery-done`,
+            data: { orderOptionNo, guestToken },
+        }),
+
+    // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
+    receiptRequest: (
+        orderNo: String,
+        { guestToken }: GuestToken,
+        { cashReceiptIssuePurposeType, cashReceiptKey }: ReceiptBody,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/guest/orders/${orderNo}/cashReceipt`,
+            data: { guestToken, cashReceiptIssuePurposeType, cashReceiptKey },
+        }),
+
+    // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
+    orderCancelDetail: (
+        orderNo: String,
+        {
+            orderRequestType,
+            claimType,
+        }: { orderRequestType?: ORDER_REQUEST_TYPE; claimType?: CLAIM_TYPE },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/guest/orders/${orderNo}/claim`,
+            params: { orderRequestType, claimType },
+        }),
+
+    // TODO guestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
+    modifyDeliveryInfo: (
+        orderNo: String,
+        guestToken: String,
+        {
+            receiverZipCd,
+            receiverAddress,
+            receiverJibunAddress,
+            receiverDetailAddress,
+            receiverName,
+            receiverContact1,
+            receiverContact2,
+            customsIdNumber,
+            countryCd,
+            deliveryMemo,
+        }: DeliveryBody,
+        { add }: { add: Boolean },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/guest/order/${orderNo}/deliveries`,
+            params: { add },
+            data: {
+                guestToken,
+                receiverZipCd,
+                receiverAddress,
+                receiverJibunAddress,
+                receiverDetailAddress,
+                receiverName,
+                receiverContact1,
+                receiverContact2,
+                customsIdNumber,
+                countryCd,
+                deliveryMemo,
+            },
+        }),
+
+    // TODO orderNo 모름, 400 error 발생 추후 테스트 필요
+    getPasswordByEmail: (
+        orderNo: String,
+        { replyType, mobileNo, email, name }: PasswordParams,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `guest/orders/${orderNo}/forgot-password`,
+            params: { replyType, mobileNo, email, name },
+        }),
+};
+
+export default guestOrder;

--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios';
 
 import request from 'api/core';
+import { defaultHeaders } from 'api/core';
 import {
     ShoppingCartBody,
     TokenIssueBody,
@@ -14,17 +15,17 @@ import {
 
 const guestOrder = {
     // TODO parameter 모름 400, 404 error 발생 추후 테스트 필요
-    getCart: (
-        {
-            orderCnt,
-            channelType,
-            optionInputs,
-            optionNo,
-            productNo,
-            cartNo,
-        }: ShoppingCartBody,
-        { divideInvalidProducts }: { divideInvalidProducts?: Boolean },
-    ): Promise<AxiosResponse> =>
+    getCart: ({
+        orderCnt,
+        channelType,
+        optionInputs,
+        optionNo,
+        productNo,
+        cartNo,
+        divideInvalidProducts,
+    }: ShoppingCartBody & {
+        divideInvalidProducts?: Boolean;
+    }): Promise<AxiosResponse> =>
         request({
             method: 'POST',
             url: '/guest/cart',
@@ -81,14 +82,20 @@ const guestOrder = {
         request({
             method: 'PUT',
             url: `/guest/order-options/${orderOptionNo}/delivery-done`,
-            data: { orderOptionNo, guestToken },
+            data: { orderOptionNo },
+            headers: Object.assign({}, defaultHeaders(), {
+                guestToken: guestToken,
+            }),
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
     requestReceipt: (
         orderNo: String,
-        { guestToken }: GuestToken,
-        { cashReceiptIssuePurposeType, cashReceiptKey }: ReceiptBody,
+        {
+            cashReceiptIssuePurposeType,
+            cashReceiptKey,
+            guestToken,
+        }: ReceiptBody & GuestToken,
     ): Promise<AxiosResponse> =>
         request({
             method: 'POST',
@@ -122,11 +129,11 @@ const guestOrder = {
             receiverName,
             receiverContact1,
             receiverContact2,
-            customsIdNumber,
+            customIdNumber,
             countryCd,
             deliveryMemo,
-        }: DeliveryBody,
-        { add }: { add: Boolean },
+            add,
+        }: DeliveryBody & { add: Boolean },
     ): Promise<AxiosResponse> =>
         request({
             method: 'PUT',
@@ -141,7 +148,7 @@ const guestOrder = {
                 receiverName,
                 receiverContact1,
                 receiverContact2,
-                customsIdNumber,
+                customIdNumber,
                 countryCd,
                 deliveryMemo,
             },

--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -27,9 +27,9 @@ const guestOrder = {
         request({
             method: 'POST',
             url: '/guest/cart',
+            params: { divideInvalidProducts },
             data: [
                 {
-                    divideInvalidProducts,
                     orderCnt,
                     channelType,
                     optionInputs,
@@ -48,6 +48,9 @@ const guestOrder = {
             method: 'GET',
             url: `/guest/orders/${orderNo}`,
             params: { orderRequestType },
+            headers: Object.assign({}, defaultHeaders(), {
+                guestToken: localStorage.getItem('guestToken') || '',
+            }),
         }),
 
     // TODO orderNo 모름, 404 error 발생 추후 테스트 필요
@@ -72,7 +75,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
-    processDeliveryCompletion: (
+    confirmDeliveryCompletion: (
         orderOptionNo: String,
     ): Promise<AxiosResponse> =>
         request({

--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -5,7 +5,6 @@ import {
     ShoppingCartBody,
     TokenIssueBody,
     ReceiptBody,
-    GuestToken,
     DeliveryBody,
     PasswordParams,
     ORDER_REQUEST_TYPE,
@@ -63,43 +62,40 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
-    confirmOrder: (
-        orderOptionNo: String,
-        { guestToken }: GuestToken,
-    ): Promise<AxiosResponse> =>
+    confirmOrder: (orderOptionNo: String): Promise<AxiosResponse> =>
         request({
             method: 'PUT',
             url: `/guest/order-options/${orderOptionNo}/confirm`,
-            data: { guestToken },
+            headers: Object.assign({}, defaultHeaders(), {
+                guestToken: localStorage.getItem('guestToken') || '',
+            }),
         }),
 
     // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
     processDeliveryCompletion: (
         orderOptionNo: String,
-        { guestToken }: GuestToken,
     ): Promise<AxiosResponse> =>
         request({
             method: 'PUT',
             url: `/guest/order-options/${orderOptionNo}/delivery-done`,
             data: { orderOptionNo },
             headers: Object.assign({}, defaultHeaders(), {
-                guestToken,
+                guestToken: localStorage.getItem('guestToken') || '',
             }),
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
     requestReceipt: (
         orderNo: String,
-        {
-            cashReceiptIssuePurposeType,
-            cashReceiptKey,
-            guestToken,
-        }: ReceiptBody & GuestToken,
+        { cashReceiptIssuePurposeType, cashReceiptKey }: ReceiptBody,
     ): Promise<AxiosResponse> =>
         request({
             method: 'POST',
             url: `/guest/orders/${orderNo}/cashReceipt`,
-            data: { guestToken, cashReceiptIssuePurposeType, cashReceiptKey },
+            data: { cashReceiptIssuePurposeType, cashReceiptKey },
+            headers: Object.assign({}, defaultHeaders(), {
+                guestToken: localStorage.getItem('guestToken') || '',
+            }),
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
@@ -119,7 +115,6 @@ const guestOrder = {
     // TODO guestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
     updateDeliveryInfo: (
         orderNo: String,
-        guestToken: String,
         {
             receiverZipCd,
             receiverAddress,
@@ -139,7 +134,6 @@ const guestOrder = {
             url: `/guest/order/${orderNo}/deliveries`,
             params: { add },
             data: {
-                guestToken,
                 receiverZipCd,
                 receiverAddress,
                 receiverJibunAddress,
@@ -151,6 +145,9 @@ const guestOrder = {
                 countryCd,
                 deliveryMemo,
             },
+            headers: Object.assign({}, defaultHeaders(), {
+                guestToken: localStorage.getItem('guestToken') || '',
+            }),
         }),
 
     // TODO orderNo 모름, 400 error 발생 추후 테스트 필요

--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -14,7 +14,7 @@ import {
 
 const guestOrder = {
     // TODO parameter 모름 400, 404 error 발생 추후 테스트 필요
-    getShoppingCart: (
+    getCart: (
         {
             orderCnt,
             channelType,
@@ -41,7 +41,7 @@ const guestOrder = {
             ],
         }),
 
-    orderDetail: (
+    getOrderDetail: (
         orderNo: String,
         { orderRequestType }: { orderRequestType?: ORDER_REQUEST_TYPE },
     ): Promise<AxiosResponse> =>
@@ -74,7 +74,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
-    deliveryCompleted: (
+    requestDeliveryCompletion: (
         orderOptionNo: String,
         { guestToken }: GuestToken,
     ): Promise<AxiosResponse> =>
@@ -85,7 +85,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
-    receiptRequest: (
+    requestReceipt: (
         orderNo: String,
         { guestToken }: GuestToken,
         { cashReceiptIssuePurposeType, cashReceiptKey }: ReceiptBody,
@@ -97,7 +97,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
-    orderCancelDetail: (
+    getOrderCancelDetail: (
         orderNo: String,
         {
             orderRequestType,
@@ -111,7 +111,7 @@ const guestOrder = {
         }),
 
     // TODO guestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
-    modifyDeliveryInfo: (
+    updateDeliveryInfo: (
         orderNo: String,
         guestToken: String,
         {

--- a/src/api/order/guestOrder.ts
+++ b/src/api/order/guestOrder.ts
@@ -63,7 +63,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
-    purchaseConfirm: (
+    confirmOrder: (
         orderOptionNo: String,
         { guestToken }: GuestToken,
     ): Promise<AxiosResponse> =>
@@ -74,7 +74,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderOptionNo 모름, 400 error 발생 추후 테스트 필요
-    requestDeliveryCompletion: (
+    processDeliveryCompletion: (
         orderOptionNo: String,
         { guestToken }: GuestToken,
     ): Promise<AxiosResponse> =>
@@ -83,7 +83,7 @@ const guestOrder = {
             url: `/guest/order-options/${orderOptionNo}/delivery-done`,
             data: { orderOptionNo },
             headers: Object.assign({}, defaultHeaders(), {
-                guestToken: guestToken,
+                guestToken,
             }),
         }),
 
@@ -103,7 +103,7 @@ const guestOrder = {
         }),
 
     // TODO GuestToken, orderNo 모름, 400 error 발생 추후 테스트 필요
-    getNonMemberOrderDetail: (
+    getGuestOrderDetail: (
         orderNo: String,
         {
             orderRequestType,

--- a/src/api/order/index.ts
+++ b/src/api/order/index.ts
@@ -1,0 +1,4 @@
+import guestOrder from 'api/order/guestOrder';
+import orderConfiguration from 'api/order/orderConfiguration';
+
+export { guestOrder, orderConfiguration };

--- a/src/api/order/orderConfiguration.ts
+++ b/src/api/order/orderConfiguration.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from 'axios';
+
+import request from 'api/core';
+
+const orderConfiguration = {
+    orderConfigs: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/order-configs',
+        }),
+};
+
+export default orderConfiguration;

--- a/src/api/order/types.ts
+++ b/src/api/order/types.ts
@@ -1,0 +1,175 @@
+export enum ORDER_REQUEST_TYPE {
+    ALL = 'ALL',
+    CLAIM = 'CLAIM',
+    NORMAL = 'NORMAL',
+    DEPOSIT_WAIT = 'DEPOSIT_WAIT',
+    PAY_DONE = 'PAY_DONE',
+    PRODUCT_PREPARE = 'PRODUCT_PREPARE',
+    DELIVERY_PREPARE = 'DELIVERY_PREPARE',
+    DELIVERY_ING = 'DELIVERY_ING',
+    DELIVERY_DONE = 'DELIVERY_DONE',
+    BUY_CONFIRM = 'BUY_CONFIRM',
+    CANCEL_DONE = 'CANCEL_DONE',
+    RETURN_DONE = 'RETURN_DONE',
+    EXCHANGE_DONE = 'EXCHANGE_DONE',
+    PAY_WAIT = 'PAY_WAIT',
+    PAY_CANCEL = 'PAY_CANCEL',
+    PAY_FAIL = 'PAY_FAIL',
+    DELETE = 'DELETE',
+    EXCHANGE_WAIT = 'EXCHANGE_WAIT',
+    REFUND_DONE = 'REFUND_DONE',
+}
+
+export enum CASH_RECEIPT_ISSUE_PURPOSE_TYPE {
+    INCOME_TAX_DEDUCTION = 'INCOME_TAX_DEDUCTION',
+    PROOF_EXPENDITURE = 'PROOF_EXPENDITURE',
+}
+
+export enum CLAIM_TYPE {
+    CANCEL = 'CANCEL',
+    RETURN = 'RETURN',
+    EXCHANGE = 'EXCHANGE',
+    NONE = 'NONE',
+}
+
+export enum COUNTRY_CD {
+    AX = 'AX',
+    AD = 'AD',
+    AU = 'AU',
+    AT = 'AT',
+    BH = 'BH',
+    BE = 'BE',
+    BZ = 'BZ',
+    BR = 'BR',
+    BN = 'BN',
+    BG = 'BG',
+    CA = 'CA',
+    ES_CANARY = 'ES_CANARY',
+    CL = 'CL',
+    CN = 'CN',
+    CO = 'CO',
+    CR = 'CR',
+    CY = 'CY',
+    CZ = 'CZ',
+    DK = 'DK',
+    EC = 'EC',
+    EG = 'EG',
+    SV = 'SV',
+    EE = 'EE',
+    FR = 'FR',
+    GF = 'GF',
+    DE = 'DE',
+    GR = 'GR',
+    GL = 'GL',
+    GU = 'GU',
+    GT = 'GT',
+    GG = 'GG',
+    GY = 'GY',
+    HK = 'HK',
+    HU = 'HU',
+    IS = 'IS',
+    ID = 'ID',
+    IE = 'IE',
+    JP = 'JP',
+    JE = 'JE',
+    JO = 'JO',
+    KR = 'KR',
+    KW = 'KW',
+    LV = 'LV',
+    LB = 'LB',
+    LI = 'LI',
+    LT = 'LT',
+    LU = 'LU',
+    MO = 'MO',
+    PT_MADEIRA = 'PT_MADEIRA',
+    MY = 'MY',
+    NL = 'NL',
+    NZ = 'NZ',
+    GB_NORTHERN_ISLAND = 'GB_NORTHERN_ISLAND',
+    NO = 'NO',
+    PY = 'PY',
+    PE = 'PE',
+    PL = 'PL',
+    PT = 'PT',
+    RO = 'RO',
+    RU = 'RU',
+    SM = 'SM',
+    SA = 'SA',
+    GB_SCOTLAND = 'GB_SCOTLAND',
+    SG = 'SG',
+    SK = 'SK',
+    SI = 'SI',
+    ES = 'ES',
+    CH = 'CH',
+    TW = 'TW',
+    TH = 'TH',
+    TR = 'TR',
+    AE = 'AE',
+    GB = 'GB',
+    US = 'US',
+    U2 = 'U2',
+    UY = 'UY',
+    VN = 'VN',
+    GB_WALES = 'GB_WALES',
+    YE = 'YE',
+    HR = 'HR',
+    MT = 'MT',
+    FI = 'FI',
+    SE = 'SE',
+}
+
+export enum REPLY_TYPE {
+    EMAIL = 'EMAIL',
+    SMS = 'SMS',
+}
+
+export type GuestToken = {
+    guestToken: String;
+};
+
+export interface OptionInputsParams {
+    inputValue: String | null;
+    inputLabel: String | null;
+}
+
+export interface ShoppingCartBody {
+    orderCnt: Number;
+    channelType: String;
+    optionInputs: OptionInputsParams[];
+    optionNo: Number;
+    productNo: Number;
+    cartNo: Number;
+}
+
+export interface TokenIssueBody {
+    password: String | null;
+    name: String | null;
+    mobileNo: String | null;
+    email: String | null;
+    orderRequestType: ORDER_REQUEST_TYPE;
+}
+
+export interface ReceiptBody {
+    cashReceiptIssuePurposeType: CASH_RECEIPT_ISSUE_PURPOSE_TYPE;
+    cashReceiptKey: String;
+}
+
+export interface DeliveryBody {
+    receiverZipCd: String;
+    receiverAddress: String;
+    receiverJibunAddress: String; // 대한민국 주소의 경우는 필수 값
+    receiverDetailAddress: String;
+    receiverName: String;
+    receiverContact1: String;
+    receiverContact2: String | null;
+    customsIdNumber: String | null;
+    countryCd: COUNTRY_CD | null; // default mall의 국가코드
+    deliveryMemo: String | null;
+}
+
+export interface PasswordParams {
+    replyType: REPLY_TYPE;
+    mobileNo?: String;
+    email?: String;
+    name?: String;
+}

--- a/src/api/order/types.ts
+++ b/src/api/order/types.ts
@@ -124,52 +124,52 @@ export enum REPLY_TYPE {
 }
 
 export type GuestToken = {
-    guestToken: String;
+    guestToken: string;
 };
 
 export interface OptionInputsParams {
-    inputValue: String | null;
-    inputLabel: String | null;
+    inputValue?: string;
+    inputLabel?: string;
 }
 
 export interface ShoppingCartBody {
-    orderCnt: Number;
-    channelType: String;
+    orderCnt: number;
+    channelType: string;
     optionInputs: OptionInputsParams[];
-    optionNo: Number;
-    productNo: Number;
-    cartNo: Number;
+    optionNo: number;
+    productNo: number;
+    cartNo: number;
 }
 
 export interface TokenIssueBody {
-    password: String | null;
-    name: String | null;
-    mobileNo: String | null;
-    email: String | null;
+    password?: string;
+    name?: string;
+    mobileNo?: string;
+    email?: string;
     orderRequestType: ORDER_REQUEST_TYPE;
 }
 
 export interface ReceiptBody {
     cashReceiptIssuePurposeType: CASH_RECEIPT_ISSUE_PURPOSE_TYPE;
-    cashReceiptKey: String;
+    cashReceiptKey: string;
 }
 
 export interface DeliveryBody {
-    receiverZipCd: String;
-    receiverAddress: String;
-    receiverJibunAddress: String; // 대한민국 주소의 경우는 필수 값
-    receiverDetailAddress: String;
-    receiverName: String;
-    receiverContact1: String;
-    receiverContact2: String | null;
-    customsIdNumber: String | null;
-    countryCd: COUNTRY_CD | null; // default mall의 국가코드
-    deliveryMemo: String | null;
+    receiverZipCd: string;
+    receiverAddress: string;
+    receiverJibunAddress: string; // 대한민국 주소의 경우는 필수 값
+    receiverDetailAddress: string;
+    receiverName: string;
+    receiverContact1: string;
+    receiverContact2?: string;
+    customsIdnumber?: string;
+    countryCd?: COUNTRY_CD; // default mall의 국가코드
+    deliveryMemo?: string;
 }
 
 export interface PasswordParams {
     replyType: REPLY_TYPE;
-    mobileNo?: String;
-    email?: String;
-    name?: String;
+    mobileNo?: string;
+    email?: string;
+    name?: string;
 }

--- a/src/api/order/types.ts
+++ b/src/api/order/types.ts
@@ -162,7 +162,7 @@ export interface DeliveryBody {
     receiverName: string;
     receiverContact1: string;
     receiverContact2?: string;
-    customsIdnumber?: string;
+    customIdNumber?: string;
     countryCd?: COUNTRY_CD; // default mall의 국가코드
     deliveryMemo?: string;
 }

--- a/src/api/order/types.ts
+++ b/src/api/order/types.ts
@@ -123,10 +123,6 @@ export enum REPLY_TYPE {
     SMS = 'SMS',
 }
 
-export type GuestToken = {
-    guestToken: string;
-};
-
 export interface OptionInputsParams {
     inputValue?: string;
     inputLabel?: string;


### PR DESCRIPTION
## guestOrder
- 비회원 장바구니 계산하여 갖고오기 (getShoppingCart)
- 비회원 주문 상세 조회하기 (orderDetail)
- 비회원 주문 토큰 발급하기 (issueOrderToken)
- 비회원 상품 주문 구매확정 처리하기 (purchaseConfirm)
- 비회원 상품 주문 배송완료 처리하기 (deliveryCompleted)
- 비회원 현금영수증 신청하기 (receiptRequest)
- 비회원 주문 상세 조회하기(클레임 상세사유 포함) (orderCancelDetail)
- 비회원 주문단위 배송정보 수정하기 (modifyDeliveryInfo)
- 비회원 초기화된 주문 패스워드 전송하기 (getPasswordByEmail)
## orderConfiguration
- 주문 설정 값 가져오기 (orderConfigs)