### PR TITLE
shop API > manage > accumulation, instagram, terms API 작성

### DIFF
--- a/src/api/manage/accumulation.ts
+++ b/src/api/manage/accumulation.ts
@@ -1,0 +1,63 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+
+export enum ACCUMULATION_REASON {
+    ADD = 'ADD',
+    SUB = 'SUB',
+}
+
+const accumulation = {
+    getAccumulationHistories: ({
+        pageNumber,
+        pageSize,
+        accumulationReason,
+        startYmd,
+        endYmd,
+        direction = ORDER_DIRECTION.DESC,
+    }: Omit<Paging, 'hasTotalCount'> & {
+        accumulationReason?: ACCUMULATION_REASON;
+    } & SearchDate & { direction?: ORDER_DIRECTION }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/accumulations',
+            params: {
+                pageNumber,
+                pageSize,
+                accumulationReason,
+                startYmd,
+                endYmd,
+                direction,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getAccumulationSummary: ({
+        expireStartYmdt,
+        expireEndYmdt,
+    }: {
+        expireStartYmdt?: string;
+        expireEndYmdt?: string;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/accumulations/summary',
+            params: { expireStartYmdt, expireEndYmdt },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getMemberExpectAccumulation: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/accumulations/waiting',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+};
+
+export default accumulation;

--- a/src/api/manage/accumulation.ts
+++ b/src/api/manage/accumulation.ts
@@ -17,7 +17,8 @@ const accumulation = {
         direction = ORDER_DIRECTION.DESC,
     }: Omit<Paging, 'hasTotalCount'> & {
         accumulationReason?: ACCUMULATION_REASON;
-    } & SearchDate & { direction?: ORDER_DIRECTION }): Promise<AxiosResponse> =>
+        direction?: ORDER_DIRECTION;
+    } & SearchDate): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/profile/accumulations',
@@ -50,7 +51,7 @@ const accumulation = {
             }),
         }),
 
-    getMemberExpectAccumulation: (): Promise<AxiosResponse> =>
+    getExpectAccumulation: (): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/profile/accumulations/waiting',

--- a/src/api/manage/index.ts
+++ b/src/api/manage/index.ts
@@ -1,4 +1,7 @@
 import address from 'api/manage/address';
 import board from 'api/manage/board';
+import accumulation from 'api/manage/accumulation';
+import instagram from 'api/manage/instagram';
+import terms from 'api/manage/terms';
 
-export { address, board };
+export { address, board, accumulation, instagram, terms };

--- a/src/api/manage/instagram.ts
+++ b/src/api/manage/instagram.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from 'axios';
+
+import request from 'api/core';
+
+const instagram = {
+    getFeeds: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/shopby/instagram/media',
+        }),
+};
+
+export default instagram;

--- a/src/api/manage/terms.ts
+++ b/src/api/manage/terms.ts
@@ -1,0 +1,62 @@
+import { AxiosResponse } from 'axios';
+
+import request from 'api/core';
+
+export enum TERMS_TYPES {
+    MALL_INTRODUCTION = 'MALL_INTRODUCTION',
+    USE = 'USE',
+    E_COMMERCE = 'E_COMMERCE',
+    PI_PROCESS = 'PI_PROCESS',
+    PI_COLLECTION_AND_USE_REQUIRED = 'PI_COLLECTION_AND_USE_REQUIRED',
+    PI_COLLECTION_AND_USE_OPTIONAL = 'PI_COLLECTION_AND_USE_OPTIONAL',
+    PI_PROCESS_CONSIGNMENT = 'PI_PROCESS_CONSIGNMENT',
+    PI_THIRD_PARTY_PROVISION = 'PI_THIRD_PARTY_PROVISION',
+    PI_COLLECTION_AND_USE_FOR_GUEST_ON_ARTICLE = 'PI_COLLECTION_AND_USE_FOR_GUEST_ON_ARTICLE',
+    ACCESS_GUIDE = 'ACCESS_GUIDE',
+    WITHDRAWAL_GUIDE = 'WITHDRAWAL_GUIDE',
+    PI_SELLER_PROVISION = 'PI_SELLER_PROVISION',
+    PI_COLLECTION_AND_USE_ON_ORDER = 'PI_COLLECTION_AND_USE_ON_ORDER',
+    ORDER_INFO_AGREE = 'ORDER_INFO_AGREE',
+    CLEARANCE_INFO_COLLECTION_AND_USE = 'CLEARANCE_INFO_COLLECTION_AND_USE',
+    TRANSFER_AGREE = 'TRANSFER_AGREE',
+    REGULAR_PAYMENT_USE = 'REGULAR_PAYMENT_USE',
+    AUTO_APPROVAL_USE = 'AUTO_APPROVAL_USE',
+    PI_LIQUOR_PURCHASE_PROVISION = 'PI_LIQUOR_PURCHASE_PROVISION',
+    PI_RESTOCK_NOTICE = 'PI_RESTOCK_NOTICE',
+}
+
+const terms = {
+    getTerms: ({
+        termsTypes,
+    }: {
+        termsTypes: TERMS_TYPES;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/terms',
+            params: { termsTypes },
+        }),
+
+    // TODO 400 error, message: termsTypes이 유효하지 않습니다.
+    getTermHistory: ({
+        termsTypes,
+        futureDaysToShow,
+    }: {
+        termsTypes: TERMS_TYPES;
+        futureDaysToShow?: string;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/terms/history',
+            params: { termsTypes, futureDaysToShow },
+        }),
+
+    // TODO 400 error, message: 해당 약관에 접근 권한이 없습니다.
+    getTermDetail: (termsNo: number): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/terms/${termsNo}`,
+        }),
+};
+
+export default terms;


### PR DESCRIPTION
## accumulation
- 적립금 이력 조회하기(getAccumulationHistories)
- 적립금 요약 조회하기(getAccumulationSummary)
- 해당 회원의 예상 적립금 조회하기(getMemberExpectAccumulation)

## instagram
- instagram 피드(게시글 목록) 조회하기(getFeeds)

## terms
- 적용 중인 몰 약관 조회하기(getTerms)
- 약관 변경이력 조회하기(getTermHistory)
- 약관 상세 조회하기(getTermDetail)