### PR TITLE
shop API > order > cart API 작성

### DIFF
--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -4,6 +4,7 @@ import request, { defaultHeaders } from 'api/core';
 import { ShoppingCartBody } from 'models/order/index';
 
 const cart = {
+    //TODO getCart, getCartCount, getCartValidation를 제외한 나머지는 cartNo 혹은 orderNo가 필수로 들어가므로 나중에 test 해야 함
     getCart: ({
         divideInvalidProducts,
     }: {
@@ -18,7 +19,6 @@ const cart = {
             }),
         }),
 
-    // TODO 400 에러, cartNo 모름, 테스트 필요
     updateCart: ({
         cartNo,
         orderCnt,
@@ -36,7 +36,6 @@ const cart = {
             }),
         }),
 
-    // TODO 400 에러, cartNo 모름, 테스트 필요
     registerCart: ({
         orderCnt,
         channelType,

--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -1,0 +1,119 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+import { ShoppingCartBody } from 'models/order/index';
+
+const cart = {
+    getCart: ({
+        divideInvalidProducts,
+    }: {
+        divideInvalidProducts?: boolean;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/cart',
+            params: { divideInvalidProducts },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    // TODO 400 에러, cartNo 모름, 테스트 필요
+    updateCart: ({
+        cartNo,
+        orderCnt,
+        optionInputs,
+    }: Pick<
+        ShoppingCartBody,
+        'cartNo' | 'orderCnt' | 'optionInputs'
+    >): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: '/cart',
+            data: [{ orderCnt, cartNo, optionInputs }],
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    // TODO 400 에러, cartNo 모름, 테스트 필요
+    registerCart: ({
+        orderCnt,
+        channelType,
+        optionInputs,
+        optionNo,
+        productNo,
+    }: Omit<ShoppingCartBody, 'cartNo'>): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/cart',
+            data: [
+                { orderCnt, channelType, optionInputs, optionNo, productNo },
+            ],
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    deleteCart: ({
+        cartNo,
+    }: Pick<ShoppingCartBody, 'cartNo'>): Promise<AxiosResponse> =>
+        request({
+            method: 'DELETE',
+            url: '/cart',
+            params: { cartNo },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getSelectedCartPrice: ({
+        cartNo,
+        divideInvalidProducts,
+    }: Pick<ShoppingCartBody, 'cartNo'> & {
+        divideInvalidProducts?: boolean;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/cart/calculate',
+            params: { cartNo, divideInvalidProducts },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getCartCount: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/cart/count',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getSelectedCartGroupPrice: ({
+        cartNo,
+        divideInvalidProducts,
+    }: Pick<ShoppingCartBody, 'cartNo'> & {
+        divideInvalidProducts?: boolean;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/cart/subset',
+            params: { cartNo, divideInvalidProducts },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getCartValidation: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/cart/validate',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+};
+
+export default cart;

--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -105,7 +105,7 @@ const cart = {
             }),
         }),
 
-    getCartValidation: (): Promise<AxiosResponse> =>
+    checkCartValidation: (): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/cart/validate',

--- a/src/api/order/index.ts
+++ b/src/api/order/index.ts
@@ -1,4 +1,5 @@
+import cart from 'api/order/cart';
 import guestOrder from 'api/order/guestOrder';
 import orderConfiguration from 'api/order/orderConfiguration';
 
-export { guestOrder, orderConfiguration };
+export { cart, guestOrder, orderConfiguration };


### PR DESCRIPTION
## cart
- 장바구니 가져오기 (getCart)
- 장바구니 수정하기 (updateCart)
- 장바구니 등록하기 (registerCart)
- 장바구니 삭제하기 (deleteCart)
- 장바구니에서 선택된 상품금액 계산하기 (getSelectedCartPrice)
- 장바구니 개수 가져오기 (getCartCount)
- 장바구니에서 선택된 항목만 장바구니 그룹별로 재계산하기 (getSelectedCartGroupPrice)
- 장바구니 저장 상품 유효성 체크하기 (checkCartValidation)