### PR TITLE
shop API > order > shippingAddress 작성

### DIFF
--- a/src/api/order/index.ts
+++ b/src/api/order/index.ts
@@ -4,5 +4,14 @@ import orderConfiguration from 'api/order/orderConfiguration';
 import orderSheet from 'api/order/orderSheet';
 import purchase from 'api/order/purchase';
 import naverPay from 'api/order/naverPay';
+import shippingAddress from './shippingAddress';
 
-export { cart, guestOrder, orderConfiguration, orderSheet, purchase, naverPay  };
+export {
+    cart,
+    guestOrder,
+    orderConfiguration,
+    orderSheet,
+    purchase,
+    naverPay,
+    shippingAddress,
+};

--- a/src/api/order/shippingAddress.ts
+++ b/src/api/order/shippingAddress.ts
@@ -1,0 +1,132 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+import { AddressRequest } from 'models/order';
+
+const shippingAddress = {
+    getShippingAddressList: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/shipping-addresses',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    registerShippingAddress: ({
+        addressName,
+        addressType,
+        defaultYn,
+        receiverName,
+        receiverZipCd,
+        receiverAddress,
+        receiverJibunAddress,
+        receiverDetailAddress,
+        receiverContact1,
+        receiverContact2,
+        customsIdNumber,
+        countryCd,
+    }: AddressRequest): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/profile/shipping-addresses',
+            data: {
+                addressName,
+                addressType,
+                defaultYn,
+                receiverName,
+                receiverZipCd,
+                receiverAddress,
+                receiverJibunAddress,
+                receiverDetailAddress,
+                receiverContact1,
+                receiverContact2,
+                customsIdNumber,
+                countryCd,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getRecentShippingAddress: (): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/shipping-addresses/recent',
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    // TODO addressNo 모름 404 error, message 없음
+    getShippingAddress: (addressNo: string): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/profile/shipping-addresses/${addressNo}`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    // TODO addressNo 모름 404 error, message: 배송지가 존재하지 않습니다 이하 함수들은 addressNo 모름
+    updateShippingAddress: (
+        addressNo: string,
+        {
+            addressName,
+            addressType,
+            defaultYn,
+            receiverName,
+            receiverZipCd,
+            receiverAddress,
+            receiverJibunAddress,
+            receiverDetailAddress,
+            receiverContact1,
+            receiverContact2,
+            customsIdNumber,
+            countryCd,
+        }: AddressRequest,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/profile/shipping-addresses/${addressNo}`,
+            data: {
+                addressName,
+                addressType,
+                defaultYn,
+                receiverName,
+                receiverZipCd,
+                receiverAddress,
+                receiverJibunAddress,
+                receiverDetailAddress,
+                receiverContact1,
+                receiverContact2,
+                customsIdNumber,
+                countryCd,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    deleteShippingAddress: (addressNo: string): Promise<AxiosResponse> =>
+        request({
+            method: 'DELETE',
+            url: `/profile/shipping-addresses/${addressNo}`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    changeShippingAddressToDefault: (
+        addressNo: string,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/profile/shipping-addresses/${addressNo}/default`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+};
+
+export default shippingAddress;

--- a/src/api/order/shippingAddress.ts
+++ b/src/api/order/shippingAddress.ts
@@ -117,9 +117,7 @@ const shippingAddress = {
             }),
         }),
 
-    changeShippingAddressToDefault: (
-        addressNo: string,
-    ): Promise<AxiosResponse> =>
+    updateDefaultShippingAddress: (addressNo: string): Promise<AxiosResponse> =>
         request({
             method: 'PUT',
             url: `/profile/shipping-addresses/${addressNo}/default`,

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -48,17 +48,17 @@ interface Products {
     productNo: number;
 }
 
-interface AddressRequest {
+export interface AddressRequest {
     receiverAddress: string;
-    receiverJibunAddress: string;
+    receiverJibunAddress?: string;
     defaultYn: string; // boolean?
     addressType: ADDRESS_TYPE;
     receiverName: string;
-    customsIdNumber: string;
-    countryCd: COUNTRY_CD;
+    customsIdNumber?: string;
+    countryCd?: COUNTRY_CD;
     receiverZipCd: string;
-    addressName: string;
-    receiverDetailAddress: string;
+    addressName?: string;
+    receiverDetailAddress?: string;
     receiverContact1: string;
     receiverContact2: string;
 }


### PR DESCRIPTION
## shippingAddress
- 배송지 목록 가져오기 (getShippingAddressList)
- 배송지 등록하기 (registerShippingAddress)
- 최근 배송지 가져오기 (getRecentShippingAddress)
- 배송지 가져오기 (getShippingAddress)
- 배송지 수정하기 (updateShippingAddress)
- 배송지 삭제하기 (deleteShippingAddress)
- 기본 배송지 수정하기 (changeShippingAddressToDefault)