### PR TITLE
shop API > auth > KCPCertification, OAuthCallback API

### DIFF
--- a/src/api/auth/KCPCertification.ts
+++ b/src/api/auth/KCPCertification.ts
@@ -1,0 +1,41 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+
+const KCPCertification = {
+    authenticateAdult: ({ key }: { key: string }): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/kcp/age-verification',
+            params: { key },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getKCPForm: ({
+        returnUrl,
+        domestic,
+    }: {
+        returnUrl: string;
+        domestic?: string;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/kcp/id-verification/form',
+            params: { returnUrl, domestic },
+        }),
+
+    getKCPCertificationResult: ({
+        key,
+    }: {
+        key: string;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/kcp/id-verification/response',
+            params: { key },
+        }),
+};
+
+export default KCPCertification;

--- a/src/api/auth/KCPCertification.ts
+++ b/src/api/auth/KCPCertification.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios';
 
 import request, { defaultHeaders } from 'api/core';
+import { Domestic } from 'models';
 
 const KCPCertification = {
     authenticateAdult: ({ key }: { key: string }): Promise<AxiosResponse> =>
@@ -18,7 +19,7 @@ const KCPCertification = {
         domestic,
     }: {
         returnUrl: string;
-        domestic?: string;
+        domestic?: Domestic;
     }): Promise<AxiosResponse> =>
         request({
             method: 'GET',

--- a/src/api/auth/OAuthCallback.ts
+++ b/src/api/auth/OAuthCallback.ts
@@ -1,0 +1,43 @@
+import { AxiosResponse } from 'axios';
+
+import request from 'api/core';
+import { OAuthBegin } from 'models/order';
+import { getPlatform } from 'utils';
+
+const OAuthCallback = {
+    openLoginPage: ({
+        clientId,
+        provider,
+        nextUrl,
+        platform,
+        state,
+    }: Omit<OAuthBegin, 'code'>): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/oauth/begin',
+            params: {
+                clientId,
+                provider,
+                nextUrl,
+                platform,
+                state,
+            },
+            headers: {},
+        }),
+
+    issueOpenIdAccessToken: ({
+        clientId,
+        provider,
+        code,
+        state,
+        nextUrl,
+    }: Omit<OAuthBegin, 'platform'>): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/oauth/callback',
+            params: { clientId, provider, code, state, nextUrl },
+            headers: {},
+        }),
+};
+
+export default OAuthCallback;

--- a/src/api/auth/OAuthCallback.ts
+++ b/src/api/auth/OAuthCallback.ts
@@ -9,7 +9,6 @@ const OAuthCallback = {
         clientId,
         provider,
         nextUrl,
-        platform,
         state,
     }: Omit<OAuthBegin, 'code'>): Promise<AxiosResponse> =>
         request({
@@ -19,7 +18,7 @@ const OAuthCallback = {
                 clientId,
                 provider,
                 nextUrl,
-                platform,
+                platform: getPlatform(),
                 state,
             },
             headers: {},
@@ -31,7 +30,7 @@ const OAuthCallback = {
         code,
         state,
         nextUrl,
-    }: Omit<OAuthBegin, 'platform'>): Promise<AxiosResponse> =>
+    }: OAuthBegin): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/oauth/callback',

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,4 +1,6 @@
 import authentication from 'api/auth/authentication';
 import captcha from 'api/auth/captcha';
+import KCPCertification from 'api/auth/KCPCertification';
+import OAuthCallback from 'api/auth/OAuthCallback';
 
-export { authentication, captcha };
+export { authentication, captcha, KCPCertification, OAuthCallback };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -377,6 +377,12 @@ enum PG_TYPE {
     VERITRANS = 'VERITRANS',
 }
 
+enum DOMESTIC {
+    TRUE = 'true',
+    FALSE = 'false',
+    NULL = 'null',
+}
+
 export {
     AUTH_TYPE,
     CERTIFICATED_USAGE,
@@ -413,4 +419,5 @@ export {
     ADDRESS_TYPE,
     PAY_TYPE,
     PG_TYPE,
+    DOMESTIC,
 };

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -7,6 +7,7 @@ import {
     ADDRESS_TYPE,
     PAY_TYPE,
     PG_TYPE,
+    OPEN_ID_PROVIDER,
 } from 'models';
 
 interface ProductCoupons {
@@ -227,9 +228,8 @@ export interface NaverPayOrderSheet {
 
 export interface OAuthBegin {
     clientId: string;
-    provider: string;
+    provider: OPEN_ID_PROVIDER;
     nextUrl: string;
-    platform: string;
     state?: string;
     code: string;
 }

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -224,3 +224,12 @@ export interface NaverPayOrderSheet {
     items: Omit<ShoppingCartBody, 'cartNo'> &
         { additionalProductNo?: number }[];
 }
+
+export interface OAuthBegin {
+    clientId: string;
+    provider: string;
+    nextUrl: string;
+    platform: string;
+    state?: string;
+    code: string;
+}


### PR DESCRIPTION
## KCPCertification
- 회원 성인인증하기 (authenticateAdult)
- KCP 본인인증 요청하기 (getKCPForm)
- KCP 본인인증 결과 조회하기 (getKCPCertificationResult)

## OAuthCallback
- OAuth 로그인 페이지 열기 (openLoginPage)
- OAuth callback 처리하기 (AccessToken 발급하기) (issueOpenIdAccessToken)