### PR TITLE
shopAPI > claim > member API 작성

### DIFF
--- a/src/api/claim/index.ts
+++ b/src/api/claim/index.ts
@@ -1,3 +1,4 @@
 import guest from 'api/claim/guest';
+import member from 'api/claim/member';
 
-export { guest };
+export { guest, member };

--- a/src/api/claim/member.ts
+++ b/src/api/claim/member.ts
@@ -19,7 +19,7 @@ const member = {
         pageSize,
         startYmd,
     }: Paging &
-        SearchDate & { claimTypes: CLAIM_TYPE }): Promise<AxiosResponse> =>
+        SearchDate & { claimTypes?: CLAIM_TYPE }): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: '/profile/claims',
@@ -128,9 +128,7 @@ const member = {
         }),
 
     updateReturnAccount: (
-        claimNo: {
-            claimNo: string;
-        },
+        claimNo: string,
         { bank, account, depositorName }: ReturnAccount,
     ): Promise<AxiosResponse> =>
         request({
@@ -142,9 +140,7 @@ const member = {
             }),
         }),
 
-    checkClaimValidation: (claimNo: {
-        claimNo: string;
-    }): Promise<AxiosResponse> =>
+    checkClaimValidation: (claimNo: string): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: `/profile/claims/${claimNo}/check-withdraw`,
@@ -287,9 +283,9 @@ const member = {
             }),
         }),
 
-    getClaimDetailByOptionNo: (orderOptionNo: {
-        orderOptionNo: string;
-    }): Promise<AxiosResponse> =>
+    getClaimDetailByOrderOptionNo: (
+        orderOptionNo: string,
+    ): Promise<AxiosResponse> =>
         request({
             method: 'GET',
             url: `/profile/order-options/${orderOptionNo}/claims/result`,
@@ -299,9 +295,7 @@ const member = {
         }),
 
     requestReturnOfSingleOption: (
-        orderOptionNo: {
-            orderOptionNo: string;
-        },
+        orderOptionNo: string,
         {
             claimImageUrls,
             claimType,

--- a/src/api/claim/member.ts
+++ b/src/api/claim/member.ts
@@ -1,0 +1,383 @@
+import { AxiosResponse } from 'axios';
+
+import request, { defaultHeaders } from 'api/core';
+import { CLAIM_TYPE } from 'models';
+import {
+    CanceledPrice,
+    CancelOptions,
+    ExchangeRequest,
+    ReturnAccount,
+    ReturnOption,
+} from 'models/claim';
+
+const member = {
+    getClaimList: ({
+        claimTypes,
+        endYmd,
+        hasTotalCount,
+        pageNumber,
+        pageSize,
+        startYmd,
+    }: Paging &
+        SearchDate & { claimTypes: CLAIM_TYPE }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: '/profile/claims',
+            params: {
+                claimTypes,
+                endYmd,
+                hasTotalCount,
+                pageNumber,
+                pageSize,
+                startYmd,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    // TODO 이하 함수들 404 error message: 리소스(order option)를 찾지 못하였습니다, 혹은 orderNo 등 모름
+    requestCancelOptions: ({
+        claimReasonDetail,
+        responsibleObjectType,
+        claimType,
+        claimedProductOptions,
+        saveBankAccountInfo,
+        bankAccountInfo,
+        claimReasonType,
+        refundsImmediately,
+    }: CancelOptions): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/profile/claims/cancel',
+            data: {
+                claimReasonDetail,
+                responsibleObjectType,
+                claimType,
+                claimedProductOptions,
+                saveBankAccountInfo,
+                bankAccountInfo,
+                claimReasonType,
+                refundsImmediately,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getRefundPrice: ({
+        claimType,
+        productCnt,
+        claimReasonType,
+        returnWayType,
+        claimedProductOptions,
+        responsibleObjectType,
+    }: CanceledPrice): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/profile/claims/estimate',
+            data: {
+                claimType,
+                productCnt,
+                claimReasonType,
+                returnWayType,
+                claimedProductOptions,
+                responsibleObjectType,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    requestReturnOfMultipleOptions: ({
+        claimImageUrls,
+        claimType,
+        productCnt,
+        claimReasonType,
+        claimReasonDetail,
+        bankAccountInfo,
+        saveBankAccountInfo,
+        returnAddress,
+        returnWayType,
+        claimedProductOptions,
+        deliveryCompanyType,
+        invoiceNo,
+        responsibleObjectType,
+    }: ReturnOption & CanceledPrice): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/profile/claims/return',
+            data: {
+                claimImageUrls,
+                claimType,
+                productCnt,
+                claimReasonType,
+                claimReasonDetail,
+                bankAccountInfo,
+                saveBankAccountInfo,
+                returnAddress,
+                returnWayType,
+                claimedProductOptions,
+                deliveryCompanyType,
+                invoiceNo,
+                responsibleObjectType,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    updateReturnAccount: (
+        claimNo: {
+            claimNo: string;
+        },
+        { bank, account, depositorName }: ReturnAccount,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/profile/claims/${claimNo}/account`,
+            data: { bank, account, depositorName },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    checkClaimValidation: (claimNo: {
+        claimNo: string;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/profile/claims/${claimNo}/check-withdraw`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getClaimDetailByClaimNo: (claimNo: string): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/profile/claims/${claimNo}/result`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    cancelClaimByClaimNo: (claimNo: string): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/profile/claims/${claimNo}/withdraw`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getContentsForClaim: (
+        orderOptionNo: string,
+        { claimType }: { claimType: CLAIM_TYPE },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/profile/order-options/${orderOptionNo}/claims`,
+            params: { claimType },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    requestCancelClaimOption: (
+        orderOptionNo: string,
+        {
+            claimReasonDetail,
+            responsibleObjectType,
+            claimType,
+            saveBankAccountInfo,
+            bankAccountInfo,
+            claimReasonType,
+            refundsImmediately,
+            productCnt,
+        }: Omit<CancelOptions, 'claimedProductOptions'> & {
+            productCnt: number;
+        },
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/profile/order-options/${orderOptionNo}/claims/cancel`,
+            data: {
+                claimReasonDetail,
+                responsibleObjectType,
+                claimType,
+                saveBankAccountInfo,
+                bankAccountInfo,
+                claimReasonType,
+                refundsImmediately,
+                productCnt,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getClaimOptionPrice: (
+        orderOptionNo: string,
+        {
+            responsibleObjectType,
+            claimType,
+            productCnt,
+            claimReasonType,
+            returnWayType,
+        }: Omit<CanceledPrice, 'claimedProductOptions'>,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/profile/order-options/${orderOptionNo}/claims/estimate`,
+            params: {
+                responsibleObjectType,
+                claimType,
+                productCnt,
+                claimReasonType,
+                returnWayType,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    requestExchange: (
+        orderOptionNo: string,
+        {
+            responsibleObjectType,
+            claimType,
+            productCnt,
+            claimReasonType,
+            returnWayType,
+            claimImageUrls,
+            claimReasonDetail,
+            bankAccountInfo,
+            saveBankAccountInfo,
+            returnAddress,
+            deliveryCompanyType,
+            invoiceNo,
+            exchangeAddress,
+            exchangeOption,
+        }: Omit<CanceledPrice, 'claimedProductOptions'> &
+            ReturnOption &
+            ExchangeRequest,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/profile/order-options/${orderOptionNo}/claims/exchange`,
+            data: {
+                responsibleObjectType,
+                claimType,
+                productCnt,
+                claimReasonType,
+                returnWayType,
+                claimImageUrls,
+                claimReasonDetail,
+                bankAccountInfo,
+                saveBankAccountInfo,
+                returnAddress,
+                deliveryCompanyType,
+                invoiceNo,
+                exchangeAddress,
+                exchangeOption,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    getClaimDetailByOptionNo: (orderOptionNo: {
+        orderOptionNo: string;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'GET',
+            url: `/profile/order-options/${orderOptionNo}/claims/result`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    requestReturnOfSingleOption: (
+        orderOptionNo: {
+            orderOptionNo: string;
+        },
+        {
+            claimImageUrls,
+            claimType,
+            productCnt,
+            claimReasonType,
+            claimReasonDetail,
+            bankAccountInfo,
+            saveBankAccountInfo,
+            returnAddress,
+            returnWayType,
+            deliveryCompanyType,
+            invoiceNo,
+            responsibleObjectType,
+        }: ReturnOption & Omit<CanceledPrice, 'claimedProductOptions'>,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/profile/order-options/${orderOptionNo}/claims/return`,
+            data: {
+                claimImageUrls,
+                claimType,
+                productCnt,
+                claimReasonType,
+                claimReasonDetail,
+                bankAccountInfo,
+                saveBankAccountInfo,
+                returnAddress,
+                returnWayType,
+                deliveryCompanyType,
+                invoiceNo,
+                responsibleObjectType,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    cancelClaimByOrderOptionNo: (
+        orderOptionNo: string,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'PUT',
+            url: `/profile/order-options/${orderOptionNo}/claims/withdraw`,
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+
+    requestCancel: (
+        orderNo: string,
+        {
+            claimReasonDetail,
+            responsibleObjectType,
+            claimType,
+            saveBankAccountInfo,
+            bankAccountInfo,
+            claimReasonType,
+            refundsImmediately,
+        }: Omit<CancelOptions, 'claimedProductOptions'>,
+    ): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: `/profile/orders/${orderNo}/claims/cancel`,
+            data: {
+                claimReasonDetail,
+                responsibleObjectType,
+                claimType,
+                saveBankAccountInfo,
+                bankAccountInfo,
+                claimReasonType,
+                refundsImmediately,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: localStorage.getItem('accessToken') || '',
+            }),
+        }),
+};
+
+export default member;

--- a/src/models/claim/index.ts
+++ b/src/models/claim/index.ts
@@ -10,7 +10,7 @@ import {
 interface BankAccountInfo {
     bankAccount?: string;
     bankDepositorName?: string;
-    bank: string;
+    bank: BANK;
     bankName?: string;
 }
 


### PR DESCRIPTION
## member
- 회원 클레임 목록 조회하기 (getClaimList)
- 회원 옵션취소 신청하기(복수옵션) (requestCancelOptions)
- 회원 클레임시 변경되는 주문의 환불 예상금액 계산하기 (getRefundPrice)
- 회원 반품 신청하기(복수옵션) (requestReturnOfMultipleOptions)
- 회원 환불 계좌 정보 수정하기 (updateReturnAccount)
- 회원 클레임 철회시 유효성 검증 타입 조회하기 (checkClaimValidation)
- 회원 클레임 상세보기(클레임 번호) (getClaimDetailByClaimNo)
- 회원 클레임 철회하기(클레임 번호) (cancelClaimByClaimNo)
- 회원 클레임 신청을 위한 정보 조회하기 (getContentsForClaim)
- 회원 옵션취소 신청하기(단일옵션) (requestCancelClaimOption)
- 회원 클레임시 변경되는 주문의 환불 예상금액 계산하기(단일옵션) (getClaimOptionPrice)
- 회원 클레임 교환 신청하기 (requestExchange)
- 회원 클레임 상세보기(주문상품 옵션번호) (getClaimDetailByOptionNo)
- 회원 반품 신청하기(단일옵션) (requestReturnOfSingleOption)
- 회원 클레임 철회하기(주문상품 옵션번호) (cancelClaimByOrderOptionNo)
- 회원 주문취소 신청하기 (requestCancel)