### PR TITLE
ProductDetail Page 작성

### DIFF
--- a/src/@types/react-i18next.d.ts
+++ b/src/@types/react-i18next.d.ts
@@ -13,6 +13,7 @@ declare module 'react-i18next' {
             main: typeof ko.main;
             manager: typeof ko.manager;
             manual: typeof ko.manual;
+            productDetail: typeof ko.productDetail;
             // about: typeof ko.about;
             //   about: typeof ko
         };

--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -40,12 +40,12 @@ const cart = {
         }),
 
     registerCart: (
-        data: Omit<ShoppingCartBody, 'cartNo'>[],
+        body: Omit<ShoppingCartBody, 'cartNo'>[],
     ): Promise<AxiosResponse> =>
         request({
             method: 'POST',
             url: '/cart',
-            data,
+            data: body,
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),

--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -2,6 +2,9 @@ import { AxiosResponse } from 'axios';
 
 import request, { defaultHeaders } from 'api/core';
 import { ShoppingCartBody } from 'models/order/index';
+import { tokenStorage } from 'utils/storage';
+
+const accessTokenInfo = tokenStorage.getAccessToken();
 
 const cart = {
     //TODO getCart, getCartCount, getCartValidation를 제외한 나머지는 cartNo 혹은 orderNo가 필수로 들어가므로 나중에 test 해야 함
@@ -15,7 +18,7 @@ const cart = {
             url: '/cart',
             params: { divideInvalidProducts },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -32,25 +35,19 @@ const cart = {
             url: '/cart',
             data: [{ orderCnt, cartNo, optionInputs }],
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
-    registerCart: ({
-        orderCnt,
-        channelType,
-        optionInputs,
-        optionNo,
-        productNo,
-    }: Omit<ShoppingCartBody, 'cartNo'>): Promise<AxiosResponse> =>
+    registerCart: (
+        data: Omit<ShoppingCartBody, 'cartNo'>[],
+    ): Promise<AxiosResponse> =>
         request({
             method: 'POST',
             url: '/cart',
-            data: [
-                { orderCnt, channelType, optionInputs, optionNo, productNo },
-            ],
+            data,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -62,7 +59,7 @@ const cart = {
             url: '/cart',
             params: { cartNo },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -77,7 +74,7 @@ const cart = {
             url: '/cart/calculate',
             params: { cartNo, divideInvalidProducts },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -86,7 +83,7 @@ const cart = {
             method: 'GET',
             url: '/cart/count',
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -101,7 +98,7 @@ const cart = {
             url: '/cart/subset',
             params: { cartNo, divideInvalidProducts },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -110,7 +107,7 @@ const cart = {
             method: 'GET',
             url: '/cart/validate',
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 };

--- a/src/api/product/product.ts
+++ b/src/api/product/product.ts
@@ -9,10 +9,15 @@ import {
 } from 'models';
 import {
     GroupCodeParams,
+    OptionResponse,
+    ProductDetailResponse,
     ProductSearchParams,
     ProductsParams,
     RestockParams,
 } from 'models/product';
+import { tokenStorage } from 'utils/storage';
+
+const accessTokenInfo = tokenStorage.getAccessToken();
 
 const product = {
     // TODO deliveryTemplateNo을 모름 500 error 발생 추후 테스트 필요
@@ -45,7 +50,7 @@ const product = {
             url: '/products/favoriteKeywords',
             params: { size },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -59,7 +64,7 @@ const product = {
             url: '/products/group-management-code',
             data: { groupManagementCodes, saleStatus, isSoldOut },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -70,7 +75,7 @@ const product = {
             url: '/products/options',
             params: { productNos },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -86,7 +91,7 @@ const product = {
             url: '/products/restock',
             data: { optionNos, privacyInfoAgreement, name, phone },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -140,17 +145,39 @@ const product = {
             },
         }),
 
+    /**
+     *상품번호 리스트로 상품을 조회하는 API입니다.
+     *(hasOptionValues: 옵션값 포함여부, default: false)
+     */
+    getProductsByProductNoList: (data: {
+        productNos: number[];
+        hasOptionValues?: boolean;
+    }): Promise<AxiosResponse> =>
+        request({
+            method: 'POST',
+            url: '/products/search-by-nos',
+            data: {
+                productNos: data.productNos,
+                hasOptionValues: data.hasOptionValues
+                    ? data.hasOptionValues
+                    : true,
+            },
+            headers: Object.assign({}, defaultHeaders(), {
+                accessToken: accessTokenInfo?.accessToken || '',
+            }),
+        }),
+
     //TODO productNo을 모름 403 error 발생 추후 테스트 필요
     getProductDetail: (
         productNo: string,
         channelType?: CHANNEL_TYPE,
-    ): Promise<AxiosResponse> =>
+    ): Promise<AxiosResponse<ProductDetailResponse>> =>
         request({
             method: 'GET',
             url: `/products/${productNo}`,
             params: { channelType },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -185,7 +212,7 @@ const product = {
                 hasOptionValues,
             },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -220,7 +247,7 @@ const product = {
                 hasOptionValues,
             },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -229,17 +256,19 @@ const product = {
             method: 'GET',
             url: `/products/${productNo}/display-categories`,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
     // TODO productNo을 모름 404 error 발생 추후 테스트 필요
-    getProductOption: (productNo: string): Promise<AxiosResponse> =>
+    getProductOption: (
+        productNo: string,
+    ): Promise<AxiosResponse<OptionResponse>> =>
         request({
             method: 'GET',
             url: `/products/${productNo}/options`,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -254,7 +283,7 @@ const product = {
             method: 'GET',
             url: `/products/${productNo}/url-shortening`,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -274,7 +303,7 @@ const product = {
             method: 'GET',
             url: `/products/${productNo}/options/${optionNo}/images`,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 };

--- a/src/api/product/product.ts
+++ b/src/api/product/product.ts
@@ -144,12 +144,18 @@ const product = {
                 shippingAreaType: params?.shippingAreaType,
             },
         }),
-
     /**
      *상품번호 리스트로 상품을 조회하는 API입니다.
      *(hasOptionValues: 옵션값 포함여부, default: false)
+     *
+     * @param body
+     *
+     *  productNos: number[];
+     *  hasOptionValues?: boolean;
+     *
+     * @returns Promise<AxiosResponse>
      */
-    getProductsByProductNoList: (data: {
+    getProductsByProductNoList: (body: {
         productNos: number[];
         hasOptionValues?: boolean;
     }): Promise<AxiosResponse> =>
@@ -157,10 +163,8 @@ const product = {
             method: 'POST',
             url: '/products/search-by-nos',
             data: {
-                productNos: data.productNos,
-                hasOptionValues: data.hasOptionValues
-                    ? data.hasOptionValues
-                    : true,
+                productNos: body.productNos,
+                hasOptionValues: body.hasOptionValues,
             },
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',

--- a/src/components/Input/StyledInput.tsx
+++ b/src/components/Input/StyledInput.tsx
@@ -19,7 +19,7 @@ const StyledInput = styled.input<InputProps>`
 
     &::placeholder {
         font-size: ${(props) => props.fontSize || '16px'};
-        color: ${(props) => props.theme.gray3};
+        color: ${(props) => props.theme.line2};
     }
 
     &:focus {

--- a/src/components/Product/ProductImageList.tsx
+++ b/src/components/Product/ProductImageList.tsx
@@ -62,7 +62,8 @@ const ProductImageList = ({
     }, [productNo]);
 
     useEffect(() => {
-        setRepresentImage(head(productImageData?.[currentOptionNo]!)!);
+        productImageData?.[currentOptionNo] &&
+            setRepresentImage(head(productImageData[currentOptionNo])!);
     }, [productImageData?.[currentOptionNo]]);
 
     return (
@@ -71,7 +72,7 @@ const ProductImageList = ({
                 <img src={representImage} alt={productImageAlt} />
             </ProductImage>
             <ProductSubImageList>
-                {productImageData &&
+                {productImageData?.[currentOptionNo] &&
                     productImageData[currentOptionNo].map((productImage) => {
                         return (
                             <ProductSubImage

--- a/src/components/Product/ProductImageList.tsx
+++ b/src/components/Product/ProductImageList.tsx
@@ -1,0 +1,90 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { head } from '@fxts/core';
+import styled from 'styled-components';
+
+const ProductImageBox = styled.div`
+    width: 50%;
+`;
+
+const ProductImage = styled.div`
+    > img {
+        display: block;
+        margin: 0 auto;
+    }
+`;
+
+const ProductSubImageList = styled.div`
+    display: flex;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    align-items: center;
+    &::-webkit-scrollbar {
+        display: block;
+        background-color: #ddd;
+        border-radius: 6px;
+    }
+    &::-webkit-scrollbar-thumb {
+        display: block;
+        background-color: #fff;
+        border: 1px solid #aaa;
+        border-radius: 6px;
+    }
+`;
+
+const ProductSubImage = styled.div`
+    width: 20%;
+    flex: 0 0 auto;
+    > img {
+        width: 100%;
+        vertical-align: middle;
+    }
+`;
+
+const ProductImageList = ({
+    productImageData,
+    setProductImageData,
+    productImageAlt,
+    currentOptionNo,
+    productNo,
+}: {
+    productImageData?: {
+        [id: number]: string[];
+    };
+    setProductImageData: Dispatch<SetStateAction<{ [id: number]: string[] }>>;
+    productImageAlt?: string;
+    currentOptionNo: number;
+    productNo: string;
+}) => {
+    const [representImage, setRepresentImage] = useState('');
+
+    useEffect(() => {
+        setProductImageData({ 0: [] });
+    }, [productNo]);
+
+    useEffect(() => {
+        setRepresentImage(head(productImageData?.[currentOptionNo]!)!);
+    }, [productImageData?.[currentOptionNo]]);
+
+    return (
+        <ProductImageBox>
+            <ProductImage>
+                <img src={representImage} alt={productImageAlt} />
+            </ProductImage>
+            <ProductSubImageList>
+                {productImageData &&
+                    productImageData[currentOptionNo].map((productImage) => {
+                        return (
+                            <ProductSubImage
+                                onClick={() => setRepresentImage(productImage)}
+                                key={productImage}
+                            >
+                                <img src={productImage} alt={productImageAlt} />
+                            </ProductSubImage>
+                        );
+                    })}
+            </ProductSubImageList>
+        </ProductImageBox>
+    );
+};
+
+export default ProductImageList;

--- a/src/components/Product/ProductOptionList.tsx
+++ b/src/components/Product/ProductOptionList.tsx
@@ -1,0 +1,223 @@
+import React, { Dispatch, SetStateAction, useEffect } from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+
+import { FlatOption, ProductOption } from 'models/product';
+import { useQuery } from 'react-query';
+import { product } from 'api/product';
+
+const ProductOptionBox = styled.div`
+    margin: 26px 0;
+    border-bottom: 1px solid #000;
+    padding-bottom: 26px;
+    > p {
+        font-size: 16px;
+        color: #191919;
+    }
+    > select {
+        margin: 22px 0;
+        border: 2px solid #ababab;
+        width: 100%;
+        color: #ababab;
+        font-size: 16px;
+        padding: 15px 10px;
+    }
+`;
+
+const ProductOptionCountBox = styled.div`
+    background: #f9f7f7;
+    padding: 10px 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    > div {
+        display: flex;
+        justify-content: space-between;
+    }
+    div:last-child {
+        align-items: flex-end;
+    }
+`;
+
+const ProductCountMinus = styled.div``;
+
+const ProductCountPlus = styled.div``;
+
+const ProductCount = styled.div`
+    color: #191919;
+`;
+
+const ProductOptionTitle = styled.div`
+    font-size: 16px;
+    color: #191919;
+`;
+
+const ProductOptionClose = styled.div`
+    cursor: pointer;
+    color: #bdbdbd;
+`;
+
+const ProductCountBox = styled.div`
+    color: #bdbdbd;
+    background: #fff;
+    display: flex;
+    > div {
+        padding: 10px;
+    }
+`;
+
+const ProductOptionList = ({
+    productNo,
+    selectOptionProducts,
+    setSelectOptionProducts,
+    setCurrentOptionNo,
+    setProductImageData,
+}: {
+    productNo: string;
+    selectOptionProducts: Map<number, ProductOption>;
+    setSelectOptionProducts: Dispatch<
+        SetStateAction<Map<number, ProductOption>>
+    >;
+    setCurrentOptionNo: Dispatch<SetStateAction<number>>;
+    setProductImageData: Dispatch<SetStateAction<{ [id: number]: string[] }>>;
+}) => {
+    const { t: productDetail } = useTranslation('productDetail');
+
+    useEffect(() => {
+        setSelectOptionProducts(new Map());
+    }, [productNo]);
+
+    const { data: productOptions } = useQuery(
+        ['productOptionDetail', { productNo }],
+        async () => await product.getProductOption(productNo),
+        {
+            select: ({ data }) => {
+                return data?.flatOptions;
+            },
+            onSuccess: (res) => {
+                setProductImageData((prev) => {
+                    res.forEach(({ optionNo, images }) => {
+                        prev[optionNo] = images.map(({ url }) => {
+                            return url;
+                        });
+                    });
+                    return { ...prev };
+                });
+            },
+            refetchOnWindowFocus: false,
+        },
+    );
+
+    const optionSelectHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        if (e.target.value === 'false') {
+            return;
+        }
+        const optionValue = JSON.parse(e.target.value);
+
+        setCurrentOptionNo(optionValue.optionNo);
+
+        setSelectOptionProducts((prev) => {
+            prev.set(optionValue.optionNo, {
+                label: optionValue.label,
+                price: optionValue.buyPrice,
+                count: 1,
+                optionNo: optionValue.optionNo,
+                productNo,
+                amountPrice: optionValue.buyPrice,
+            });
+            return new Map(prev);
+        });
+    };
+
+    const productCountHandler =
+        (updateCount: number, optionNo: number) => () => {
+            if (selectOptionProducts.get(optionNo)?.count! + updateCount <= 0) {
+                alert(productDetail('countAlert'));
+                return;
+            }
+            setSelectOptionProducts((prev) => {
+                prev.set(optionNo, {
+                    label: prev.get(optionNo)?.label!,
+                    price: prev.get(optionNo)?.price!,
+                    count: prev.get(optionNo)?.count! + updateCount,
+                    optionNo,
+                    productNo,
+                    amountPrice:
+                        prev.get(optionNo)?.price! *
+                        (prev.get(optionNo)?.count! + updateCount),
+                });
+                return new Map(prev);
+            });
+        };
+
+    return (
+        <ProductOptionBox>
+            <p>{productDetail('chooseOption')}</p>
+            <select onChange={optionSelectHandler}>
+                <option value={'false'}>
+                    {productDetail('chooseOption')}.
+                </option>
+                {productOptions?.map((productOption) => {
+                    return (
+                        <option
+                            key={productOption.optionNo}
+                            value={JSON.stringify(productOption)}
+                        >
+                            {productOption.label}
+                        </option>
+                    );
+                })}
+            </select>
+            <div>
+                {Array.from(selectOptionProducts.values()).map(
+                    ({ count, label, amountPrice, optionNo }) => {
+                        return (
+                            <ProductOptionCountBox key={optionNo}>
+                                <div>
+                                    <ProductOptionTitle>
+                                        {label}
+                                    </ProductOptionTitle>
+                                    <ProductOptionClose
+                                        onClick={() =>
+                                            setSelectOptionProducts((prev) => {
+                                                prev.delete(optionNo);
+                                                return new Map(prev);
+                                            })
+                                        }
+                                    >
+                                        X
+                                    </ProductOptionClose>
+                                </div>
+                                <div>
+                                    <ProductCountBox>
+                                        <ProductCountMinus
+                                            onClick={productCountHandler(
+                                                -1,
+                                                optionNo,
+                                            )}
+                                        >
+                                            -
+                                        </ProductCountMinus>
+                                        <ProductCount>{count}</ProductCount>
+                                        <ProductCountPlus
+                                            onClick={productCountHandler(
+                                                1,
+                                                optionNo,
+                                            )}
+                                        >
+                                            +
+                                        </ProductCountPlus>
+                                    </ProductCountBox>
+                                    <p>{amountPrice}</p>
+                                </div>
+                            </ProductOptionCountBox>
+                        );
+                    },
+                )}
+            </div>
+        </ProductOptionBox>
+    );
+};
+
+export default ProductOptionList;

--- a/src/components/Product/RelatedProduct.tsx
+++ b/src/components/Product/RelatedProduct.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+import { head } from '@fxts/core';
+import styled from 'styled-components';
+import { AxiosResponse } from 'axios';
+import { product } from 'api/product';
+import { useQueries } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { ProductDetailResponse } from 'models/product';
+
+const RelatedProductContainer = styled.div`
+    display: flex;
+    justify-content: left;
+    overflow-y: hidden;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    &::-webkit-scrollbar {
+        display: block;
+        background-color: #ddd;
+        border-radius: 6px;
+    }
+    &::-webkit-scrollbar-thumb {
+        display: block;
+        background-color: #fff;
+        border: 1px solid #aaa;
+        border-radius: 6px;
+    }
+`;
+
+const RelatedProductBox = styled.div`
+    width: 20%;
+    margin-right: 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    flex: 0 0 auto;
+    > img {
+        display: block;
+        width: 100%;
+    }
+`;
+
+const RelatedProductImage = styled.div`
+    background: #f8f8fa;
+    > img {
+        width: 70%;
+        padding: 15% 0;
+        display: block;
+        margin: 0 auto;
+    }
+`;
+
+const RelatedProductDesc = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-top: 19px;
+    > div {
+        > p {
+            color: #858585;
+            margin-bottom: 5px;
+        }
+        > p:first-child {
+            color: #191919;
+        }
+    }
+`;
+
+const RelatedProductTitle = styled.div``;
+
+const RelatedProductPrice = styled.div``;
+
+const RelatedProduct = ({
+    productData,
+}: {
+    productData?: AxiosResponse<ProductDetailResponse>;
+}) => {
+    const navigate = useNavigate();
+
+    const relatedProducts = useQueries(
+        productData?.data.relatedProductNos?.map((productNo) => {
+            return {
+                queryKey: ['relatedProduct', productNo],
+                queryFn: async () =>
+                    await product.getProductDetail(productNo.toString()),
+                refetchOnWindowFocus: false,
+            };
+        }) ?? [],
+    );
+
+    return (
+        <RelatedProductContainer>
+            {relatedProducts?.map((relatedProduct) => {
+                return (
+                    relatedProduct.data?.data && (
+                        <RelatedProductBox
+                            onClick={() =>
+                                navigate(
+                                    `/product/detail/${relatedProduct.data?.data.baseInfo.productNo}`,
+                                )
+                            }
+                            key={relatedProduct.data?.data.baseInfo.productNo}
+                        >
+                            <RelatedProductImage>
+                                <img
+                                    src={head(
+                                        relatedProduct.data?.data.baseInfo
+                                            .imageUrls,
+                                    )}
+                                    alt={
+                                        relatedProduct.data?.data.baseInfo
+                                            .productName
+                                    }
+                                />
+                            </RelatedProductImage>
+                            <RelatedProductDesc>
+                                <RelatedProductTitle>
+                                    <p>
+                                        {
+                                            relatedProduct.data?.data.baseInfo
+                                                .productName
+                                        }
+                                    </p>
+                                    <p>
+                                        {
+                                            relatedProduct.data?.data.baseInfo
+                                                .promotionText
+                                        }
+                                    </p>
+                                </RelatedProductTitle>
+                                <RelatedProductPrice>
+                                    <p>
+                                        {
+                                            relatedProduct.data?.data.price
+                                                .salePrice
+                                        }
+                                    </p>
+                                    <p>
+                                        {relatedProduct.data?.data.price
+                                            .salePrice -
+                                            relatedProduct.data?.data.price
+                                                .immediateDiscountAmt}
+                                    </p>
+                                </RelatedProductPrice>
+                            </RelatedProductDesc>
+                        </RelatedProductBox>
+                    )
+                );
+            })}
+        </RelatedProductContainer>
+    );
+};
+
+export default RelatedProduct;

--- a/src/components/SectionDropdown/SectionDropdown.tsx
+++ b/src/components/SectionDropdown/SectionDropdown.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { ReactComponent as More } from 'assets/icon-select-more.svg';
 
 const DropdownContainer = styled.div`
-    background-color: ${({ theme }) => theme.white};
+    background-color: ${({ theme }) => theme.primary};
     margin-bottom: 10px;
 `;
 
@@ -12,7 +12,7 @@ const DropdownTitleContainer = styled.div`
     justify-content: space-between;
     align-items: center;
     padding: 15px 20px;
-    border-bottom: 1px solid ${(props) => props.theme.gray1};
+    border-bottom: 1px solid ${(props) => props.theme.line2};
 `;
 
 const Title = styled.p``;
@@ -20,19 +20,19 @@ const Title = styled.p``;
 const ToggleArrow = styled(More)`
     width: 30px;
     height: 30px;
-    stroke: ${(props) => props.theme.black};
+    stroke: ${(props) => props.theme.bg3};
     transition: 0.5s ease-in-out;
     ${(props: { $isVisible: boolean }) => (props.$isVisible ? openStyles : '')}
 `;
 
 const openStyles = css`
     transform: rotate(180deg);
-    stroke: ${(props) => props.theme.blue};
+    stroke: ${(props) => props.theme.bg1};
 `;
 
 const DropdownContentsContainer = styled.div`
     display: block;
-    background: ${(props) => props.theme.gray1};
+    background: ${(props) => props.theme.bg1};
     font-size: 14px;
     color: #767676;
     line-height: 16px;

--- a/src/locales/jp/index.ts
+++ b/src/locales/jp/index.ts
@@ -1,5 +1,6 @@
 import main from 'locales/jp/main.json';
 import manager from 'locales/jp/manager.json';
 import manual from 'locales/jp/manual.json';
+import productDetail from 'locales/jp/productDetail.json';
 
-export { main, manager, manual };
+export { main, manager, manual, productDetail };

--- a/src/locales/jp/productDetail.json
+++ b/src/locales/jp/productDetail.json
@@ -1,0 +1,20 @@
+{
+    "countAlert": "1개 이상 구매하여야 합니다!",
+    "successCartAlert": "장바구니 등록이 완료됐습니다.",
+    "failCartAlert": "장바구니 등록이 실패했습니다. 다시 등록해주세요",
+    "accumulateBenefits": "적립혜택",
+    "memberPoint": "회원 적립금",
+    "chooseOption": "원하는 옵션을 선택하세요",
+    "amountPrice": "총 상품 금액",
+    "amount": "총",
+    "count": "개",
+    "shippingInformation": "배송정보",
+    "shippingCost": "배송비",
+    "buyNow": "바로구매",
+    "goToManual": "매뉴얼 바로가기",
+    "voiceCaddieManager": "보이스캐디 매니저",
+    "voiceCaddieManual": "보이스캐디 매뉴얼",
+    "productDetail": "제품 상세",
+    "productSpecifications": "제품 스펙",
+    "notice": "유의사항"
+}

--- a/src/locales/ko/index.ts
+++ b/src/locales/ko/index.ts
@@ -1,5 +1,6 @@
 import main from 'locales/ko/main.json';
 import manager from 'locales/ko/manager.json';
 import manual from 'locales/ko/manual.json';
+import productDetail from 'locales/ko/productDetail.json';
 
-export { main, manager, manual };
+export { main, manager, manual, productDetail };

--- a/src/locales/ko/productDetail.json
+++ b/src/locales/ko/productDetail.json
@@ -1,0 +1,20 @@
+{
+    "countAlert": "1개 이상 구매하여야 합니다!",
+    "successCartAlert": "장바구니 등록이 완료됐습니다.",
+    "failCartAlert": "장바구니 등록이 실패했습니다. 다시 등록해주세요",
+    "accumulateBenefits": "적립혜택",
+    "memberPoint": "회원 적립금",
+    "chooseOption": "원하는 옵션을 선택하세요",
+    "amountPrice": "총 상품 금액",
+    "amount": "총",
+    "count": "개",
+    "shippingInformation": "배송정보",
+    "shippingCost": "배송비",
+    "buyNow": "바로구매",
+    "goToManual": "매뉴얼 바로가기",
+    "voiceCaddieManager": "보이스캐디 매니저",
+    "voiceCaddieManual": "보이스캐디 매뉴얼",
+    "productDetail": "제품 상세",
+    "productSpecifications": "제품 스펙",
+    "notice": "유의사항"
+}

--- a/src/locales/ko/productDetail.json
+++ b/src/locales/ko/productDetail.json
@@ -2,6 +2,7 @@
     "countAlert": "1개 이상 구매하여야 합니다!",
     "successCartAlert": "장바구니 등록이 완료됐습니다.",
     "failCartAlert": "장바구니 등록이 실패했습니다. 다시 등록해주세요",
+    "failBuyAlert": "구매에 실패했습니다. 다시 시도해주세요",
     "accumulateBenefits": "적립혜택",
     "memberPoint": "회원 적립금",
     "chooseOption": "원하는 옵션을 선택하세요",

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -130,7 +130,7 @@ export interface ShoppingCartBody {
     optionInputs?: OptionInputsParams[];
     optionNo: number;
     productNo: number;
-    cartNo: number;
+    cartNo?: number;
 }
 
 export interface TokenIssueBody {

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -119,14 +119,15 @@ interface Orderer {
 }
 
 export interface OptionInputsParams {
-    inputValue?: string;
-    inputLabel?: string;
+    inputValue: string;
+    inputLabel: string;
+    required: boolean;
 }
 
 export interface ShoppingCartBody {
     orderCnt: number;
     channelType: string;
-    optionInputs: OptionInputsParams[];
+    optionInputs?: OptionInputsParams[];
     optionNo: number;
     productNo: number;
     cartNo: number;

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -41,7 +41,7 @@ interface OptionInputs {
 
 interface Products {
     rentalInfos?: RentalInfos[];
-    recurringPaymentDelivery: RecurringPaymentDelivery;
+    recurringPaymentDelivery?: RecurringPaymentDelivery;
     channelType: string;
     orderCnt: number;
     optionInputs?: OptionInputs[];
@@ -232,4 +232,17 @@ export interface OAuthBegin {
     nextUrl: string;
     state?: string;
     code: string;
+}
+
+export interface OrderSheetResponse {
+    products: Products[];
+    productCoupons: any[];
+    cartNos: any[];
+    trackingKey: string;
+    channelType: string;
+}
+
+export interface RentalInfo {
+    rentalPeriod: number;
+    monthlyRentalAmount: number;
 }

--- a/src/models/product/index.ts
+++ b/src/models/product/index.ts
@@ -186,3 +186,328 @@ export interface OptionValue {
     optionValue: string;
     stockCnt: number;
 }
+
+export interface ProductDetailResponse {
+    baseInfo: BaseInfo;
+    deliveryDate: DeliveryDate;
+    stock: Stock;
+    price: Price;
+    deliveryFee: DeliveryFee;
+    limitations: Limitations;
+    counter: Counter;
+    categories: Category[];
+    brand: any;
+    liked: boolean;
+    partner: Partner;
+    status: Status;
+    partnerNotice: PartnerNotice;
+    reservationData: ReservationData;
+    deliveryGuide: string;
+    afterServiceGuide: string;
+    refundGuide: string;
+    exchangeGuide: string;
+    liquorDelegationGuide: string;
+    relatedProductNos: number[];
+    shippingInfo: ShippingInfo;
+    groupManagementCode: string;
+    groupManagementCodeName: string;
+    regularDelivery: any;
+    rentalInfos: RentalInfo[];
+    displayableStock: boolean;
+    saleMethodType: string;
+    reviewAvailable: boolean;
+    mainBestProductYn: boolean;
+}
+
+export interface BaseInfo {
+    productNo: number;
+    saleStartYmdt: string;
+    saleEndYmdt: string;
+    salePeriodType: string;
+    registerYmdt: string;
+    promotionText: string;
+    productName: string;
+    productNameEn: string;
+    imageUrls: string[];
+    placeOriginLabel: string;
+    placeOriginEtcLabel: string;
+    manufactureYmdt: string;
+    expirationYmdt: string;
+    contentHeader: string;
+    content: string;
+    contentFooter: string;
+    dutyInfo: string;
+    stickerLabels: string[];
+    stickerInfos: StickerInfo[];
+    optionImageViewable: boolean;
+    productManagementCd: string;
+    purchaseGuide: string;
+    accumulationUseYn: string;
+    deliveryCustomerInfo: string;
+    certificationType: string;
+    certifications: Certification[];
+    productGroup: string;
+    hsCode: string;
+    usableRestockNoti: boolean;
+    productType: string;
+    customPropertise: CustomPropertise[];
+    couponUseYn: string;
+    minorPurchaseYn: string;
+}
+
+export interface StickerInfo {
+    type: string;
+    label: string;
+    name: string;
+}
+
+export interface Certification {
+    no: number;
+    type: string;
+    organization: string;
+    code: string;
+    target: string;
+    date: string;
+}
+
+export interface CustomPropertise {
+    propNo: number;
+    propValueNo: number;
+    propName: string;
+    propValue: string;
+    multipleSelectionYn: string;
+}
+
+export interface DeliveryDate {
+    daysAfterPurchase: any;
+    daysOfWeek: any;
+    period: any;
+}
+
+export interface Stock {
+    saleCnt: number;
+    stockCnt: number;
+    mainStockCnt: number;
+}
+
+export interface Price {
+    salePrice: number;
+    immediateDiscountAmt: number;
+    immediateDiscountUnitType: string;
+    additionDiscountAmt: number;
+    additionDiscountUnitType: string;
+    additionDiscountValue: number;
+    minSalePrice: number;
+    maxSalePrice: number;
+    maxAdditionDiscountAmt: number;
+    maxDiscountAmount: number;
+    unitName: string;
+    unitNameType: string;
+    unitPrice: number;
+    maxCouponAmt: number;
+    couponDiscountAmt: number;
+    accumulationAmtWhenBuyConfirm: number;
+    accumulationRate: number;
+    contentsIfPausing: string;
+}
+
+export interface DeliveryFee {
+    deliveryConditionType: string;
+    deliveryAmt: number;
+    aboveDeliveryAmt: any;
+    returnDeliveryAmt: number;
+    deliveryType: string;
+    deliveryCompanyType: string;
+    perOrderCnt: any;
+    defaultDeliveryConditionLabel: string;
+    deliveryAmtLabels: any[];
+    deliveryCompanyTypeLabel: string;
+    deliveryConditionDetails: any[];
+    remoteDeliveryAreaFees: any[];
+    deliveryPrePayment: boolean;
+    returnWarehouse: ReturnWarehouse;
+    deliveryCustomerInfo: string;
+}
+
+export interface ReturnWarehouse {
+    warehouseNo: number;
+    warehouseName: string;
+    defaultReleaseWarehouseYn: string;
+    defaultReturnWarehouseYn: string;
+    partnerNo: number;
+    address: string;
+    detailAddress: string;
+    zipCd: string;
+    overseaAddress1: string;
+    overseaAddress2: string;
+    overseaCity: string;
+    overseaRegion: string;
+    countryCd: string;
+    warehouseAddressType: string;
+    deleteYn: string;
+    registerAdminNo: number;
+    updateYmdt: string;
+    updateAdminNo: number;
+    addressStr: string;
+}
+
+export interface Limitations {
+    minBuyCnt: number;
+    maxBuyPersonCnt: number;
+    maxBuyTimeCnt: number;
+    maxBuyDays: number;
+    maxBuyPeriodCnt: number;
+    memberOnly: boolean;
+    canAddToCart: boolean;
+    refundable: boolean;
+    naverPayHandling: boolean;
+}
+
+export interface Counter {
+    likeCnt: number;
+    reviewCnt: number;
+    inquiryCnt: number;
+    myInquiryCnt: number;
+}
+
+export interface Category {
+    fullCategoryLabel: string;
+    categories: Category2[];
+}
+
+export interface Category2 {
+    label: string;
+    depth: number;
+    categoryNo: number;
+}
+
+export interface Partner {
+    partnerName: string;
+    businessRegistrationNo: string;
+    companyName: string;
+    onlineMarketingBusinessDeclarationNo: string;
+    ownerName: string;
+    officeAddressLabel: string;
+    phoneNo: string;
+    faxNo: string;
+    email: string;
+}
+
+export interface Status {
+    saleStatusType: string;
+    soldout: boolean;
+    display: boolean;
+    productClassType: string;
+}
+
+export interface PartnerNotice {
+    title: string;
+    content: string;
+}
+
+export interface ReservationData {
+    reservationStartYmdt: string;
+    reservationEndYmdt: string;
+    reservationDeliveryYmdt: string;
+    reservationStockCnt: number;
+}
+
+export interface ShippingInfo {
+    shippingAvailable: boolean;
+    shippingConfig: ShippingConfig;
+}
+
+export interface ShippingConfig {
+    shippingAreaType: string;
+    shippingAreaPartnerNo: number;
+    combinable: boolean;
+    internationalShippingAvailable: boolean;
+    templateNo: number;
+}
+
+export interface RentalInfo {
+    rentalPeriod: number;
+    monthlyRentalAmount: number;
+    creditRating: number;
+}
+
+export interface OptionResponse {
+    type: string;
+    selectType: string;
+    labels: string[];
+    multiLevelOptions: MultiLevelOption[];
+    flatOptions: FlatOption[];
+    inputs: Input[];
+    displayableStock: boolean;
+    additionalProducts: any[];
+}
+
+export interface MultiLevelOption {
+    label: string;
+    value: string;
+    children: Children[];
+}
+
+export interface Children {
+    label: string;
+    value: string;
+    optionNo: number;
+    addPrice: number;
+    saleCnt: number;
+    stockCnt: number;
+    reservationStockCnt: number;
+    saleType: string;
+    main: boolean;
+    images: Image[];
+    optionManagementCd: string;
+    buyPrice: number;
+    forcedSoldOut: boolean;
+    children: any;
+    rentalInfo: RentalInfo[];
+}
+
+export interface Image {
+    url: string;
+    main: boolean;
+}
+
+export interface RentalInfo {
+    rentalPeriod: number;
+    monthlyRentalAmount: number;
+    creditRating: number;
+}
+
+export interface FlatOption {
+    optionNo: number;
+    label: string;
+    value: string;
+    addPrice: number;
+    saleCnt: number;
+    stockCnt: number;
+    reservationStockCnt: number;
+    saleType: string;
+    main: boolean;
+    images: Image2[];
+    optionManagementCd: string;
+    buyPrice: number;
+    forcedSoldOut: boolean;
+    rentalInfo: RentalInfo2[];
+}
+
+export interface Image2 {
+    url: string;
+    main: boolean;
+}
+
+export interface RentalInfo2 {
+    rentalPeriod: number;
+    monthlyRentalAmount: number;
+    creditRating: number;
+}
+
+export interface Input {
+    inputNo: number;
+    inputLabel: string;
+    inputMatchingType: string;
+    required: boolean;
+}

--- a/src/models/product/index.ts
+++ b/src/models/product/index.ts
@@ -511,3 +511,12 @@ export interface Input {
     inputMatchingType: string;
     required: boolean;
 }
+
+export interface ProductOption {
+    label?: string;
+    price?: number;
+    count: number;
+    optionNo: number;
+    productNo: string;
+    amountPrice?: number;
+}

--- a/src/pages/Member/Join.tsx
+++ b/src/pages/Member/Join.tsx
@@ -158,7 +158,7 @@ const Join = () => {
                 );
 
                 dispatch(fetchProfile());
-                navigate('/signup/signUpCompleted');
+                navigate('/member/join-completed');
             }
         } catch (error) {
             alert('알 수 없는 에러 발생!');

--- a/src/pages/Member/JoinAgreement.tsx
+++ b/src/pages/Member/JoinAgreement.tsx
@@ -34,7 +34,7 @@ const JoinAgreement = () => {
         if (checkAgree.length !== VCTerms.length) {
             alert('모든 약관에 동의해주세요');
         } else {
-            navigate('/member/joinStep', {
+            navigate('/member/join', {
                 state: {
                     joinTermsAgreements: checkAgree,
                     // certificated: boolean

--- a/src/pages/Product/ProductDetail.tsx
+++ b/src/pages/Product/ProductDetail.tsx
@@ -257,7 +257,25 @@ const ProductDetail = () => {
     const addCartHandler = () => {
         if (selectOptionProducts.size <= 0) return;
 
-        const cartList: Omit<ShoppingCartBody, 'cartNo'>[] = [];
+        const cartList: ShoppingCartBody[] = [];
+        if (!member) {
+            Array.from(selectOptionProducts.values()).forEach(
+                (optionProduct) => {
+                    const currentCart = {
+                        orderCnt: optionProduct.count,
+                        channelType: CHANNEL_TYPE.NAVER_EP,
+                        optionInputs: [],
+                        optionNo: optionProduct.optionNo,
+                        productNo: parseFloat(optionProduct.productNo),
+                        cartNo: optionProduct.optionNo,
+                    };
+                    cartList.push(currentCart);
+                },
+            );
+            dispatch(setCart(cartList));
+            alert(productDetail('successCartAlert'));
+            return;
+        }
         Array.from(selectOptionProducts.values()).forEach((optionProduct) => {
             const currentCart = {
                 orderCnt: optionProduct.count,
@@ -268,12 +286,6 @@ const ProductDetail = () => {
             };
             cartList.push(currentCart);
         });
-
-        if (!member) {
-            dispatch(setCart(cartList));
-            alert(productDetail('successCartAlert'));
-            return;
-        }
 
         cartMutate(cartList);
     };

--- a/src/pages/Product/ProductDetail.tsx
+++ b/src/pages/Product/ProductDetail.tsx
@@ -1,7 +1,776 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useQueries, useQuery, useMutation } from 'react-query';
+import { head } from '@fxts/core';
+import { AxiosResponse } from 'axios';
+import { faBasketShopping } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { product } from 'api/product';
+import media from 'utils/styles/media';
+import { CHANNEL_TYPE } from 'models';
+import { cart } from 'api/order';
+import { ShoppingCartBody } from 'models/order';
+import { ProductDetailResponse } from 'models/product/index';
+
+const ProductContainer = styled.div`
+    padding: 0 20px;
+    margin: 50px auto;
+    width: 1200px;
+    ${media.large} {
+        width: 100%;
+    } ;
+`;
+
+const ProductContainerTop = styled.div`
+    display: flex;
+    width: 100%;
+`;
+
+const ProductImageBox = styled.div`
+    width: 50%;
+`;
+
+const ProductImage = styled.div`
+    > img {
+        display: block;
+        margin: 0 auto;
+    }
+`;
+
+const ProductSubImageList = styled.div`
+    display: flex;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    align-items: center;
+    &::-webkit-scrollbar {
+        display: block;
+        background-color: #ddd;
+        border-radius: 6px;
+    }
+    &::-webkit-scrollbar-thumb {
+        display: block;
+        background-color: #fff;
+        border: 1px solid #aaa;
+        border-radius: 6px;
+    }
+`;
+
+const ProductSubImage = styled.div`
+    width: 20%;
+    flex: 0 0 auto;
+    > img {
+        width: 100%;
+        vertical-align: middle;
+    }
+`;
+
+const ProductInfoBox = styled.div`
+    width: 50%;
+`;
+
+const ProductTitleBox = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin: 10px 0;
+`;
+
+const ProductTitle = styled.h2`
+    font-size: 64px;
+    color: #191919;
+`;
+const ProductText = styled.div`
+    font-size: 16px;
+    color: #858585;
+`;
+
+const ShareButton = styled.div``;
+
+const ProductPriceBox = styled.div``;
+
+const ProductPrice = styled.div`
+    margin-top: 40px;
+    > p {
+        font-weight: bold;
+        font-size: 40px;
+        margin-bottom: 10px;
+        > span {
+            font-weight: normal;
+            font-size: 24px;
+            color: #191919;
+        }
+        > span.basic_price {
+            color: #a8a8a8;
+        }
+    }
+`;
+
+const ProductAccumulationBox = styled.div`
+    line-height: 15px;
+    border-bottom: 1px solid #dbdbdb;
+    padding: 5px 0 30px;
+    > p {
+        font-size: 12px;
+    }
+    > p:first-child {
+        font-size: 16px;
+    }
+`;
+
+const ProductOptionBox = styled.div`
+    margin: 26px 0;
+    border-bottom: 1px solid #000;
+    padding-bottom: 26px;
+    > p {
+        font-size: 16px;
+        color: #191919;
+    }
+    > select {
+        margin: 22px 0;
+        border: 2px solid #ababab;
+        width: 100%;
+        color: #ababab;
+        font-size: 16px;
+        padding: 15px 10px;
+    }
+`;
+
+const ProductOptionCountBox = styled.div`
+    background: #f9f7f7;
+    padding: 10px 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    > div {
+        display: flex;
+        justify-content: space-between;
+    }
+    div:last-child {
+        align-items: flex-end;
+    }
+`;
+
+const ProductOptionTitle = styled.div`
+    font-size: 16px;
+    color: #191919;
+`;
+
+const ProductOptionClose = styled.div`
+    cursor: pointer;
+    color: #bdbdbd;
+`;
+
+const ProductCountBox = styled.div`
+    color: #bdbdbd;
+    background: #fff;
+    display: flex;
+    > div {
+        padding: 10px;
+    }
+`;
+
+const ProductCountMinus = styled.div``;
+
+const ProductCountPlus = styled.div``;
+
+const ProductCount = styled.div`
+    color: #191919;
+`;
+
+const ProductAmount = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    > p {
+        font-size: 24px;
+        font-weight: bold;
+        color: #191919;
+        > span {
+            color: #a8a8a8;
+            font-size: 16px;
+        }
+    }
+`;
+
+const DeliveryInfoBox = styled.div`
+    font-size: 16px;
+    > div,
+    p {
+        margin-bottom: 10px;
+    }
+`;
+
+const DeliveryFee = styled.div`
+    font-size: 12px;
+`;
+
+const DeliveryDesc = styled.div`
+    font-size: 12px;
+    color: #999;
+`;
+
+const PurchaseBox = styled.div`
+    margin-top: 30px;
+    display: flex;
+    justify-content: space-between;
+    > a {
+        width: 80%;
+        text-align: center;
+        padding: 15px 0;
+        background: #191919;
+        color: #fff;
+        font-weight: bold;
+        font-size: 24px;
+    }
+`;
+
+const CartButton = styled.div`
+    width: 70px;
+    height: 67px;
+    border: 1px solid #191919;
+    > div {
+        font-size: 30px;
+        text-align: center;
+        line-height: 67px;
+        > svg {
+            width: 40px;
+            height: 40px;
+        }
+    }
+`;
+
+const ProductContainerBottom = styled.div``;
+
+const ExternalLinkBox = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 70%;
+    margin: 107px auto 148px;
+    > a {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        > span {
+            font-size: 24px;
+        }
+    }
+`;
+
+const ExternalIcon = styled.span`
+    width: 57px;
+    height: 57px;
+    background: #000;
+    border-radius: 7px;
+    margin-right: 10px;
+`;
+
+const ProductDescriptionBox = styled.div`
+    display: flex;
+    justify-content: center;
+    width: 60%;
+    text-align: center;
+    font-size: 24px;
+    margin: 0 auto 138px;
+`;
+
+const ProductDescription = styled.div<{ isActive?: boolean }>`
+    width: 33.33%;
+    border-bottom: 3px solid
+        ${(props) => (props.isActive ? '#191919' : '#dbdbdb')};
+    padding: 22px 0;
+`;
+
+const ProductContentBox = styled.div`
+    > p {
+        width: fit-content;
+        margin: 0 auto;
+    }
+    img {
+        display: block;
+        margin: 0 auto;
+    }
+`;
+
+const RelatedProductContainer = styled.div`
+    display: flex;
+    justify-content: left;
+    overflow-y: hidden;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    &::-webkit-scrollbar {
+        display: block;
+        background-color: #ddd;
+        border-radius: 6px;
+    }
+    &::-webkit-scrollbar-thumb {
+        display: block;
+        background-color: #fff;
+        border: 1px solid #aaa;
+        border-radius: 6px;
+    }
+`;
+
+const RelatedProduct = styled.div`
+    width: 20%;
+    margin-right: 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    flex: 0 0 auto;
+    > img {
+        display: block;
+        width: 100%;
+    }
+`;
+
+const RelatedProductImage = styled.div`
+    background: #f8f8fa;
+    > img {
+        width: 70%;
+        padding: 15% 0;
+        display: block;
+        margin: 0 auto;
+    }
+`;
+
+const RelatedProductDesc = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-top: 19px;
+    > div {
+        > p {
+            color: #858585;
+            margin-bottom: 5px;
+        }
+        > p:first-child {
+            color: #191919;
+        }
+    }
+`;
+
+const RelatedProductTitle = styled.div``;
+
+const RelatedProductPrice = styled.div``;
+
+interface ProductOption {
+    label?: string;
+    price?: number;
+    count: number;
+    optionNo: number;
+    productNo: string;
+    amountPrice?: number;
+}
 
 const ProductDetail = () => {
-    return <div>ProductDetail</div>;
+    const { productNo } = useParams() as { productNo: string };
+    const [productImageList, setProductImageList] = useState<string[]>();
+    const [representImage, setRepresentImage] = useState('');
+    const [optionProduct, setOptionProduct] = useState(
+        new Map<number, ProductOption>(),
+    );
+    const [relatedProducts, setRelatedProducts] = useState<
+        ProductDetailResponse[]
+    >([]);
+    const [selectedDesc, setSelectedDesc] = useState<number>(0);
+
+    const navigate = useNavigate();
+
+    const { data: productData } = useQuery(
+        ['productDetail', { productNo }],
+        async () => await product.getProductDetail(productNo),
+        {
+            onSuccess: (res) => {
+                setProductImageList(res.data?.baseInfo?.imageUrls);
+                setRepresentImage(res.data?.baseInfo?.imageUrls?.[0]);
+            },
+            refetchOnWindowFocus: false,
+        },
+    );
+
+    useEffect(() => {
+        setRepresentImage(productImageList?.[0]!);
+    }, [productImageList]);
+
+    const { data: productOptions } = useQuery(
+        ['productOptionDetail', { productNo }],
+        async () => await product.getProductOption(productNo),
+        {
+            select: ({ data }) => {
+                return data?.flatOptions;
+            },
+            refetchOnWindowFocus: false,
+        },
+    );
+
+    useQueries(
+        productData?.data.relatedProductNos?.map((productNo) => {
+            return {
+                queryKey: ['relatedProduct', productNo],
+                queryFn: async () =>
+                    await product.getProductDetail(productNo.toString()),
+                onSuccess: (res: AxiosResponse<ProductDetailResponse>) => {
+                    setRelatedProducts((prev) => {
+                        return [...prev, res.data];
+                    });
+                },
+                refetchOnWindowFocus: false,
+            };
+        }) ?? [],
+    );
+
+    const optionSelectHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        if (e.target.value !== '0') {
+            const optionValue = JSON.parse(e.target.value);
+            setProductImageList(
+                optionValue.images.map((element: { url: string }) => {
+                    return element.url;
+                }),
+            );
+            if (
+                optionProduct.get(optionValue.optionNo) === optionValue.optionNo
+            )
+                return;
+            setOptionProduct((prev) => {
+                prev.set(optionValue.optionNo, {
+                    label: optionValue.label,
+                    price: optionValue.buyPrice,
+                    count: 1,
+                    optionNo: optionValue.optionNo,
+                    productNo,
+                    amountPrice: optionValue.buyPrice,
+                });
+                return new Map(prev);
+            });
+        }
+    };
+
+    const productCountHandler = (number: number, optionNo: number) => () => {
+        if (optionProduct.get(optionNo)?.count! + number <= 0) {
+            alert('1개 이상 구매하여야 합니다!');
+            return;
+        }
+        setOptionProduct((prev) => {
+            prev.set(optionNo, {
+                label: prev.get(optionNo)?.label!,
+                price: prev.get(optionNo)?.price!,
+                count: prev.get(optionNo)?.count! + number,
+                optionNo,
+                productNo,
+                amountPrice:
+                    prev.get(optionNo)?.price! *
+                    (prev.get(optionNo)?.count! + number),
+            });
+            return new Map(prev);
+        });
+    };
+
+    const { mutate, isLoading: isCartLoading } = useMutation(
+        async (cartList: Omit<ShoppingCartBody, 'cartNo'>[]) =>
+            await cart.registerCart(cartList),
+        {
+            onSuccess: (res) => {
+                console.log(res);
+                alert('장바구니 등록이 완료됐습니다.');
+            },
+            onError: () => {
+                alert('장바구니 등록이 실패했습니다. 다시 등록해주세요');
+            },
+        },
+    );
+
+    const cartHandler = async () => {
+        if (optionProduct.size <= 0) {
+            return;
+        }
+
+        const cartList: Omit<ShoppingCartBody, 'cartNo'>[] = [];
+        Array.from(optionProduct.values()).forEach((ele) => {
+            const currentCart = {
+                orderCnt: ele.count,
+                channelType: CHANNEL_TYPE.NAVER_EP,
+                optionInputs: [],
+                optionNo: ele.optionNo,
+                productNo: parseFloat(ele.productNo),
+            };
+            cartList.push(currentCart);
+        });
+        mutate(cartList);
+    };
+
+    return (
+        <ProductContainer>
+            <ProductContainerTop>
+                <ProductImageBox>
+                    <ProductImage>
+                        <img src={representImage} alt='' />
+                    </ProductImage>
+                    <ProductSubImageList>
+                        {productImageList?.map((element) => {
+                            return (
+                                <ProductSubImage
+                                    onClick={() => setRepresentImage(element)}
+                                    key={element}
+                                >
+                                    <img
+                                        src={element}
+                                        alt={
+                                            productData?.data.baseInfo
+                                                .productName
+                                        }
+                                    />
+                                </ProductSubImage>
+                            );
+                        })}
+                    </ProductSubImageList>
+                </ProductImageBox>
+                <ProductInfoBox>
+                    <ProductTitleBox>
+                        <div>
+                            <ProductTitle>
+                                {productData?.data.baseInfo.productName}
+                            </ProductTitle>
+                            <ProductText>
+                                {productData?.data.baseInfo.promotionText}
+                            </ProductText>
+                        </div>
+                        <ShareButton>
+                            공유하기 버튼(따로 컴포넌트로 빼자)
+                        </ShareButton>
+                    </ProductTitleBox>
+                    <ProductPriceBox>
+                        <ProductPrice>
+                            <p>
+                                {productData &&
+                                    productData.data.price.salePrice -
+                                        productData.data.price
+                                            .immediateDiscountAmt}
+                                <span>원 </span>
+                                <span
+                                    className='basic_price'
+                                    style={{ textDecoration: 'line-through' }}
+                                >
+                                    {productData?.data.price.salePrice}
+                                </span>
+                            </p>
+                        </ProductPrice>
+                        <ProductAccumulationBox>
+                            <p>적립혜택</p>
+                            <p>
+                                회원 적립금{' '}
+                                {
+                                    productData?.data.price
+                                        .accumulationAmtWhenBuyConfirm
+                                }
+                                원
+                            </p>
+                        </ProductAccumulationBox>
+                    </ProductPriceBox>
+                    <ProductOptionBox>
+                        <p>원하는 옵션을 선택하세요</p>
+                        <select onChange={optionSelectHandler}>
+                            <option value={0}>원하는 옵션을 선택하세요.</option>
+                            {productOptions?.map((element) => {
+                                return (
+                                    <option
+                                        key={element.optionNo}
+                                        value={JSON.stringify(element)}
+                                    >
+                                        {element.label}
+                                    </option>
+                                );
+                            })}
+                        </select>
+                        <div>
+                            {Array.from(optionProduct.values()).map(
+                                ({ count, label, amountPrice, optionNo }) => {
+                                    return (
+                                        <ProductOptionCountBox key={optionNo}>
+                                            <div>
+                                                <ProductOptionTitle>
+                                                    {label}
+                                                </ProductOptionTitle>
+                                                <ProductOptionClose
+                                                    onClick={() =>
+                                                        setOptionProduct(
+                                                            (prev) => {
+                                                                prev.delete(
+                                                                    optionNo,
+                                                                );
+                                                                return new Map(
+                                                                    prev,
+                                                                );
+                                                            },
+                                                        )
+                                                    }
+                                                >
+                                                    X
+                                                </ProductOptionClose>
+                                            </div>
+                                            <div>
+                                                <ProductCountBox>
+                                                    <ProductCountMinus
+                                                        onClick={productCountHandler(
+                                                            -1,
+                                                            optionNo,
+                                                        )}
+                                                    >
+                                                        -
+                                                    </ProductCountMinus>
+                                                    <ProductCount>
+                                                        {count}
+                                                    </ProductCount>
+                                                    <ProductCountPlus
+                                                        onClick={productCountHandler(
+                                                            1,
+                                                            optionNo,
+                                                        )}
+                                                    >
+                                                        +
+                                                    </ProductCountPlus>
+                                                </ProductCountBox>
+                                                <p>{amountPrice}</p>
+                                            </div>
+                                        </ProductOptionCountBox>
+                                    );
+                                },
+                            )}
+                        </div>
+                    </ProductOptionBox>
+                    <ProductAmount>
+                        <p>
+                            총 상품 금액{' '}
+                            <span>
+                                총{' '}
+                                {optionProduct.size > 0 &&
+                                    Array.from(optionProduct.values()).reduce(
+                                        (prev, cur) => {
+                                            return prev + cur.count!;
+                                        },
+                                        0,
+                                    )}
+                                개
+                            </span>
+                        </p>
+                        <p>
+                            {optionProduct.size > 0 &&
+                                Array.from(optionProduct.values()).reduce(
+                                    (prev, cur) => {
+                                        return prev + cur.amountPrice!;
+                                    },
+                                    0,
+                                )}
+                            원
+                        </p>
+                    </ProductAmount>
+                    <DeliveryInfoBox>
+                        <p>배송정보</p>
+                        <DeliveryFee>
+                            배송비{' '}
+                            <span>
+                                {productData?.data.deliveryFee.deliveryAmt}
+                            </span>
+                        </DeliveryFee>
+                        <DeliveryDesc>
+                            {
+                                productData?.data.deliveryFee
+                                    .defaultDeliveryConditionLabel
+                            }
+                        </DeliveryDesc>
+                    </DeliveryInfoBox>
+                    <PurchaseBox>
+                        <CartButton onClick={cartHandler}>
+                            {isCartLoading ? (
+                                '등록중'
+                            ) : (
+                                <div>
+                                    <FontAwesomeIcon icon={faBasketShopping} />
+                                </div>
+                            )}
+                        </CartButton>
+                        <Link to={''}>바로구매</Link>
+                    </PurchaseBox>
+                </ProductInfoBox>
+            </ProductContainerTop>
+            <ProductContainerBottom>
+                <ExternalLinkBox>
+                    <a href=''>
+                        <ExternalIcon></ExternalIcon>{' '}
+                        <span>매뉴얼 바로가기 &gt;</span>
+                    </a>
+                    <a href=''>
+                        <ExternalIcon></ExternalIcon>{' '}
+                        <span>보이스캐디 매니저 &gt;</span>
+                    </a>
+                    <a href=''>
+                        <ExternalIcon></ExternalIcon>
+                        <span>보이스캐디 매뉴얼 &gt;</span>
+                    </a>
+                </ExternalLinkBox>
+                <ProductDescriptionBox>
+                    <ProductDescription
+                        isActive={selectedDesc === 0}
+                        onClick={() => setSelectedDesc(0)}
+                    >
+                        <a href='#productContent'>제품 상세</a>
+                    </ProductDescription>
+                    <ProductDescription
+                        isActive={selectedDesc === 1}
+                        onClick={() => setSelectedDesc(1)}
+                    >
+                        <a href='#productContent'>제품 스펙</a>
+                    </ProductDescription>
+                    <ProductDescription
+                        isActive={selectedDesc === 2}
+                        onClick={() => setSelectedDesc(2)}
+                    >
+                        <a href='#productContent'>유의사항</a>
+                    </ProductDescription>
+                </ProductDescriptionBox>
+                <ProductContentBox
+                    id='productContent'
+                    dangerouslySetInnerHTML={{
+                        __html: productData?.data.baseInfo.content ?? '',
+                    }}
+                ></ProductContentBox>
+                <RelatedProductContainer>
+                    {relatedProducts.map(({ baseInfo, price }) => {
+                        return (
+                            <RelatedProduct
+                                onClick={() =>
+                                    navigate(
+                                        `/product/detail/${baseInfo.productNo}`,
+                                    )
+                                }
+                                key={baseInfo.productNo}
+                            >
+                                <RelatedProductImage>
+                                    <img
+                                        src={head(baseInfo.imageUrls)}
+                                        alt={baseInfo.productName}
+                                    />
+                                </RelatedProductImage>
+                                <RelatedProductDesc>
+                                    <RelatedProductTitle>
+                                        <p>{baseInfo.productName}</p>
+                                        <p>{baseInfo.promotionText}</p>
+                                    </RelatedProductTitle>
+                                    <RelatedProductPrice>
+                                        <p>{price.salePrice}</p>
+                                        <p>
+                                            {price.salePrice -
+                                                price.immediateDiscountAmt}
+                                        </p>
+                                    </RelatedProductPrice>
+                                </RelatedProductDesc>
+                            </RelatedProduct>
+                        );
+                    })}
+                </RelatedProductContainer>
+            </ProductContainerBottom>
+        </ProductContainer>
+    );
 };
 
 export default ProductDetail;

--- a/src/pages/Product/ProductDetail.tsx
+++ b/src/pages/Product/ProductDetail.tsx
@@ -6,6 +6,7 @@ import { head } from '@fxts/core';
 import { AxiosResponse } from 'axios';
 import { faBasketShopping } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
 
 import { product } from 'api/product';
 import media from 'utils/styles/media';
@@ -377,6 +378,8 @@ const ProductDetail = () => {
 
     const navigate = useNavigate();
 
+    const { t } = useTranslation(['productDetail']);
+
     const { data: productData } = useQuery(
         ['productDetail', { productNo }],
         async () => await product.getProductDetail(productNo),
@@ -448,7 +451,7 @@ const ProductDetail = () => {
 
     const productCountHandler = (number: number, optionNo: number) => () => {
         if (optionProduct.get(optionNo)?.count! + number <= 0) {
-            alert('1개 이상 구매하여야 합니다!');
+            alert(t('productDetail:countAlert'));
             return;
         }
         setOptionProduct((prev) => {
@@ -471,11 +474,10 @@ const ProductDetail = () => {
             await cart.registerCart(cartList),
         {
             onSuccess: (res) => {
-                console.log(res);
-                alert('장바구니 등록이 완료됐습니다.');
+                alert(t('productDetail:successCartAlert'));
             },
             onError: () => {
-                alert('장바구니 등록이 실패했습니다. 다시 등록해주세요');
+                alert(t('productDetail:failCartAlert'));
             },
         },
     );
@@ -504,7 +506,10 @@ const ProductDetail = () => {
             <ProductContainerTop>
                 <ProductImageBox>
                     <ProductImage>
-                        <img src={representImage} alt='' />
+                        <img
+                            src={representImage}
+                            alt={productData?.data.baseInfo.productName}
+                        />
                     </ProductImage>
                     <ProductSubImageList>
                         {productImageList?.map((element) => {
@@ -535,9 +540,7 @@ const ProductDetail = () => {
                                 {productData?.data.baseInfo.promotionText}
                             </ProductText>
                         </div>
-                        <ShareButton>
-                            공유하기 버튼(따로 컴포넌트로 빼자)
-                        </ShareButton>
+                        <ShareButton>공유하기 버튼</ShareButton>
                     </ProductTitleBox>
                     <ProductPriceBox>
                         <ProductPrice>
@@ -556,9 +559,9 @@ const ProductDetail = () => {
                             </p>
                         </ProductPrice>
                         <ProductAccumulationBox>
-                            <p>적립혜택</p>
+                            <p>{t('productDetail:accumulateBenefits')}</p>
                             <p>
-                                회원 적립금{' '}
+                                {t('productDetail:accumulateBenefits')}{' '}
                                 {
                                     productData?.data.price
                                         .accumulationAmtWhenBuyConfirm
@@ -568,9 +571,11 @@ const ProductDetail = () => {
                         </ProductAccumulationBox>
                     </ProductPriceBox>
                     <ProductOptionBox>
-                        <p>원하는 옵션을 선택하세요</p>
+                        <p>{t('productDetail:chooseOption')}</p>
                         <select onChange={optionSelectHandler}>
-                            <option value={0}>원하는 옵션을 선택하세요.</option>
+                            <option value={0}>
+                                {t('productDetail:chooseOption')}.
+                            </option>
                             {productOptions?.map((element) => {
                                 return (
                                     <option
@@ -640,9 +645,9 @@ const ProductDetail = () => {
                     </ProductOptionBox>
                     <ProductAmount>
                         <p>
-                            총 상품 금액{' '}
+                            {t('productDetail:amountPrice')}{' '}
                             <span>
-                                총{' '}
+                                {t('productDetail:amount')}{' '}
                                 {optionProduct.size > 0 &&
                                     Array.from(optionProduct.values()).reduce(
                                         (prev, cur) => {
@@ -650,7 +655,7 @@ const ProductDetail = () => {
                                         },
                                         0,
                                     )}
-                                개
+                                {t('productDetail:count')}
                             </span>
                         </p>
                         <p>
@@ -665,9 +670,9 @@ const ProductDetail = () => {
                         </p>
                     </ProductAmount>
                     <DeliveryInfoBox>
-                        <p>배송정보</p>
+                        <p>{t('productDetail:shippingInformation')}</p>
                         <DeliveryFee>
-                            배송비{' '}
+                            {t('productDetail:shippingCost')}{' '}
                             <span>
                                 {productData?.data.deliveryFee.deliveryAmt}
                             </span>
@@ -689,7 +694,7 @@ const ProductDetail = () => {
                                 </div>
                             )}
                         </CartButton>
-                        <Link to={''}>바로구매</Link>
+                        <Link to={''}>{t('productDetail:buyNow')}</Link>
                     </PurchaseBox>
                 </ProductInfoBox>
             </ProductContainerTop>
@@ -697,15 +702,17 @@ const ProductDetail = () => {
                 <ExternalLinkBox>
                     <a href=''>
                         <ExternalIcon></ExternalIcon>{' '}
-                        <span>매뉴얼 바로가기 &gt;</span>
+                        <span>{t('productDetail:goToManual')} &gt;</span>
                     </a>
                     <a href=''>
                         <ExternalIcon></ExternalIcon>{' '}
-                        <span>보이스캐디 매니저 &gt;</span>
+                        <span>
+                            {t('productDetail:voiceCaddieManager')} &gt;
+                        </span>
                     </a>
                     <a href=''>
                         <ExternalIcon></ExternalIcon>
-                        <span>보이스캐디 매뉴얼 &gt;</span>
+                        <span>{t('productDetail:voiceCaddieManual')} &gt;</span>
                     </a>
                 </ExternalLinkBox>
                 <ProductDescriptionBox>
@@ -713,19 +720,25 @@ const ProductDetail = () => {
                         isActive={selectedDesc === 0}
                         onClick={() => setSelectedDesc(0)}
                     >
-                        <a href='#productContent'>제품 상세</a>
+                        <a href='#productContent'>
+                            {t('productDetail:productDetail')}
+                        </a>
                     </ProductDescription>
                     <ProductDescription
                         isActive={selectedDesc === 1}
                         onClick={() => setSelectedDesc(1)}
                     >
-                        <a href='#productContent'>제품 스펙</a>
+                        <a href='#productContent'>
+                            {t('productDetail:productSpecifications')}
+                        </a>
                     </ProductDescription>
                     <ProductDescription
                         isActive={selectedDesc === 2}
                         onClick={() => setSelectedDesc(2)}
                     >
-                        <a href='#productContent'>유의사항</a>
+                        <a href='#productContent'>
+                            {t('productDetail:notice')}
+                        </a>
                     </ProductDescription>
                 </ProductDescriptionBox>
                 <ProductContentBox

--- a/src/pages/Product/ProductDetail.tsx
+++ b/src/pages/Product/ProductDetail.tsx
@@ -224,6 +224,9 @@ const PurchaseBox = styled.div`
         color: #fff;
         font-weight: bold;
         font-size: 24px;
+        > span {
+            vertical-align: middle;
+        }
     }
 `;
 
@@ -694,7 +697,9 @@ const ProductDetail = () => {
                                 </div>
                             )}
                         </CartButton>
-                        <Link to={''}>{t('productDetail:buyNow')}</Link>
+                        <Link to={''}>
+                            <span>{t('productDetail:buyNow')}</span>
+                        </Link>
                     </PurchaseBox>
                 </ProductInfoBox>
             </ProductContainerTop>

--- a/src/router/ProductRouter.tsx
+++ b/src/router/ProductRouter.tsx
@@ -6,8 +6,8 @@ import NotFound from 'pages/NotFound';
 
 const ProductRouter = () => (
     <Routes>
-        <Route path='product/list' element={<ProductList />} />
-        <Route path='product/detail:/productNo' element={<ProductDetail />} />
+        <Route path='/:categoryNo' element={<ProductList />} />
+        <Route path='detail/:productNo' element={<ProductDetail />} />
         <Route path='*' element={<NotFound />} />
     </Routes>
 );

--- a/src/state/reducers/index.ts
+++ b/src/state/reducers/index.ts
@@ -5,11 +5,13 @@ import store from 'state/store';
 import mallSlice from 'state/slices/mallSlice';
 import tokenSlice from 'state/slices/tokenSlice';
 import memberSlice from 'state/slices/memberSlice';
+import cartSlice from 'state/slices/cartSlice';
 
 const rootReducer = combineReducers({
     mall: mallSlice.reducer,
     token: tokenSlice.reducer,
     member: memberSlice.reducer,
+    cart: cartSlice.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/state/slices/cartSlice.ts
+++ b/src/state/slices/cartSlice.ts
@@ -1,0 +1,69 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { ShoppingCartBody } from 'models/order';
+
+const cartInitialState: {
+    data: Omit<ShoppingCartBody, 'cartNo'>[];
+} = {
+    data: [],
+};
+
+export const cartSlice = createSlice({
+    name: 'member',
+    initialState: cartInitialState,
+    reducers: {
+        setCart: (state, action) => {
+            if (state.data.length > 0) {
+                return {
+                    data: [
+                        ...state.data.map((base) => {
+                            let addedOrderCnt: Omit<
+                                ShoppingCartBody,
+                                'cartNo'
+                            >[] = [];
+                            action.payload.forEach(
+                                (now: {
+                                    optionNo: number;
+                                    orderCnt: number;
+                                }) => {
+                                    if (base?.optionNo === now.optionNo) {
+                                        const orderCnt =
+                                            base.orderCnt + now.orderCnt;
+                                        addedOrderCnt.push({
+                                            ...base,
+                                            orderCnt,
+                                        });
+                                    }
+                                },
+                            );
+
+                            if (addedOrderCnt.length > 0)
+                                return addedOrderCnt[0];
+                            return base;
+                        }),
+                        ...action.payload.filter(
+                            (item: Omit<ShoppingCartBody, 'cartNo'>) => {
+                                let isDuplicate = false;
+
+                                state.data.forEach((base) => {
+                                    if (item.optionNo === base.optionNo)
+                                        isDuplicate = true;
+                                });
+
+                                if (isDuplicate) return;
+
+                                return item;
+                            },
+                        ),
+                    ],
+                };
+            }
+            return {
+                data: [...state.data, ...action.payload],
+            };
+        },
+    },
+});
+
+export const { setCart } = cartSlice.actions;
+
+export default cartSlice;


### PR DESCRIPTION
## Storyboard
- 51 ~ 52page
- (xd) 66 ~ 67page
## Desc
*productNo: 주소의 query parameter, 상품의 번호이다.

### 이미지 리스트(ProductImageList)
- 불러와야 할 이미지는 메인 상품 이미지 리스트와 옵션별 이미지 리스트 가 있음
- 메인 상품 이미지와 옵션별 이미지 리스트는 호출 하는 api가 다름(getProductDetail, getProductOption)
- 각 api가 호출 될 때마다 setProductImageData에 해당 옵션의 optionNo를 key로 하고 이미지 리스트를 배열로 담아준다.
- 서브 이미지를 클릭할때마다 메인 이미지가 해당 이미지로 변경
- optionNo가 바뀔때마다 해당 옵션의 상품 이미지 리스트로 변경 된다.
- productNo가 바뀔때마다 해당 상품 

### 옵션 목록(ProductOptionList)
- api로 호출한 옵션 목록을 select의 option에 매핑한다.
- option을 클릭 한 경우 선택한 옵션 목록에 해당 옵션 상품 추가 및 optionNo 변경
- 선택한 옵션 목록은 개수 수정 및 삭제 가능
- productNo가 바뀔경우(주소의 query parameter)가 변경 되는 경우 선택한 옵션 목록(setOptionProduct) 초기화

### 연관 상품 리스트(RelatedProduct)
- 해당 상품에 판매자가 등록한 연관 상품 리스트 호출(shopBy에 있는 연관 상품 호출 api 는 상품 설명은 전송되지 않으므로 useQueries를 사용하여 모든 상품정보를 호출한다.)

### 장바구니 등록
#### - 회원 
선택한 옵션 목록을 상품 장바구니 등록 api 호출 한다.

#### - 비회원
- 선택한 옵션 목록을 LocalStorage및 redux에 저장한다.
- 만일 장바구니에 있는 제품을 다시 장바구니에 등록하는 경우 등록하려는 제품의 개수 만큼 장바구니에 있는 제품의 개수 증가

### 구매하기
- 선택한 옵션이 없는 경우 구매 하기는 무응답
- 구매하기를 클릭한 이후 해당 주문의 주문번호가 파라미터인 주문서 페이지로 이동한다. 