### PR TITLE
 메인 슬라이드 배너, 기타 섹션 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "@fxts/core": "^0.8.0",
+        "@fxts/core": "^0.9.0",
         "@hookform/error-message": "^2.0.0",
         "@reduxjs/toolkit": "^1.8.1",
         "@testing-library/jest-dom": "^5.16.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "react-hook-form": "^7.31.1",
         "react-i18next": "^11.16.9",
         "react-loader-spinner": "^6.0.0-0",
+        "react-player": "^2.10.1",
         "react-query": "^3.39.0",
         "react-redux": "^8.0.1",
         "react-router-dom": "^6.3.0",

--- a/src/components/Button/SlideButton.stories.tsx
+++ b/src/components/Button/SlideButton.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import SlideButton from 'components/Button/SlideButton';
+
+export default {
+    component: SlideButton,
+} as ComponentMeta<typeof SlideButton>;
+
+const Template: ComponentStory<typeof SlideButton> = ({
+    slideButtonType,
+    ...props
+}) => <SlideButton slideButtonType={slideButtonType} {...props} />;
+
+export const PrevSlideButton = Template.bind({});
+PrevSlideButton.args = {
+    slideButtonType: 'prev',
+};
+
+export const NextSlideButton = Template.bind({});
+NextSlideButton.args = {
+    slideButtonType: 'next',
+};

--- a/src/components/Button/SlideButton.tsx
+++ b/src/components/Button/SlideButton.tsx
@@ -1,0 +1,49 @@
+import { ButtonHTMLAttributes, forwardRef, Ref } from 'react';
+import styled, { css } from 'styled-components';
+
+import { ReactComponent as PrevIcon } from 'assets/icons/prev_button.svg';
+import { ReactComponent as NextIcon } from 'assets/icons/next_button.svg';
+
+interface SlideButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    slideButtonType: 'prev' | 'next';
+}
+
+const StyledButton = styled.button<{ slideButtonType: 'prev' | 'next' }>`
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1;
+    cursor: pointer;
+
+    ${(props) =>
+        props.slideButtonType === 'prev' &&
+        css`
+            left: 44.2px;
+        `}
+
+    ${(props) =>
+        props.slideButtonType === 'next' &&
+        css`
+            right: 44.2px;
+        `}
+`;
+
+const SlideButton = forwardRef(
+    (
+        { slideButtonType, ...props }: SlideButtonProps,
+        ref: Ref<HTMLButtonElement>,
+    ) => {
+        return (
+            <StyledButton
+                ref={ref}
+                slideButtonType={slideButtonType}
+                {...props}
+            >
+                {slideButtonType === 'prev' && <PrevIcon />}
+                {slideButtonType === 'next' && <NextIcon />}
+            </StyledButton>
+        );
+    },
+);
+
+export default SlideButton;

--- a/src/components/Button/ViewMoreButton.stories.tsx
+++ b/src/components/Button/ViewMoreButton.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import ViewMoreButton from 'components/Button/ViewMoreButton';
+
+export default {
+    component: ViewMoreButton,
+} as ComponentMeta<typeof ViewMoreButton>;
+
+const Template: ComponentStory<typeof ViewMoreButton> = ({
+    children,
+    ...props
+}) => <ViewMoreButton {...props}>{children}</ViewMoreButton>;
+
+export const MainSlideViewMoreButton = Template.bind({});
+MainSlideViewMoreButton.args = {
+    to: '/',
+    target: '_blank',
+    children: '자세히 보기',
+};

--- a/src/components/Button/ViewMoreButton.tsx
+++ b/src/components/Button/ViewMoreButton.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import styled from 'styled-components';
+
+import media from 'utils/styles/media';
+
+interface ViewMoreButtonProps extends LinkProps {}
+
+const StyledLink = styled(Link)`
+    display: block;
+    border-radius: 25px;
+    background-color: #191919;
+    color: #fff;
+    height: 50px;
+    font-size: 20px;
+    padding: 10px 20px;
+    width: 138px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto;
+    letter-spacing: 0;
+
+    ${media.medium} {
+        font-size: 16px;
+        line-height: 24px;
+        padding: 10px 28px;
+    }
+`;
+
+const ViewMoreButton: FC<ViewMoreButtonProps> = ({ children, ...props }) => {
+    return <StyledLink {...props}>{children}</StyledLink>;
+};
+
+export default ViewMoreButton;

--- a/src/components/Main/ETCSection.tsx
+++ b/src/components/Main/ETCSection.tsx
@@ -1,0 +1,103 @@
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { sort } from '@fxts/core';
+
+import LayoutResponsive from 'components/shared/LayoutResponsive';
+import media from 'utils/styles/media';
+import { getLinkTarget } from 'utils/html';
+import { BannerInfo } from 'models/display';
+
+interface ETCSectionProps {
+    iconWidth?: number;
+    iconHeight?: number;
+    banners: BannerInfo[];
+}
+
+const ETCSectionWrapper = styled(LayoutResponsive)`
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    padding: 150px 0;
+    flex-wrap: wrap;
+
+    ${media.medium} {
+        width: 380px;
+        padding: 90px 0;
+    }
+`;
+
+const StyledLink = styled(Link)<{ width: number; height: number }>`
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 30px;
+    width: ${(props) => props.width}px;
+    height: ${(props) => props.height}px;
+
+    ${media.medium} {
+        margin-bottom: 10px;
+    }
+`;
+
+const IconWrapper = styled.div`
+    ${media.medium} {
+        flex: 1 1 40%;
+        margin-bottom: 50px;
+
+        &:nth-child(3),
+        &:nth-child(4) {
+            margin-bottom: 0;
+        }
+    }
+`;
+
+const IconTitle = styled.p`
+    font-size: 16px;
+    line-height: 24px;
+    color: #191919;
+
+    ${media.medium} {
+        font-size: 14px;
+        line-height: 20px;
+    }
+`;
+
+const ETCSection: FC<ETCSectionProps> = ({
+    iconWidth = 50,
+    iconHeight = 50,
+    banners,
+}) => {
+    return (
+        <ETCSectionWrapper type='medium'>
+            {sort((a, b) => a.displayOrder > b.displayOrder, banners).map(
+                ({
+                    bannerNo,
+                    landingUrl,
+                    imageUrl,
+                    name,
+                    browerTargetType,
+                }) => (
+                    <IconWrapper key={bannerNo}>
+                        <StyledLink
+                            width={iconWidth}
+                            height={iconHeight}
+                            to={landingUrl}
+                            target={getLinkTarget(browerTargetType)}
+                        >
+                            <img
+                                src={imageUrl}
+                                alt={name}
+                                width={iconWidth}
+                                height={iconHeight}
+                            />
+                        </StyledLink>
+                        <IconTitle>{name}</IconTitle>
+                    </IconWrapper>
+                ),
+            )}
+        </ETCSectionWrapper>
+    );
+};
+
+export default ETCSection;

--- a/src/components/Main/MainSlideBanner.tsx
+++ b/src/components/Main/MainSlideBanner.tsx
@@ -1,0 +1,189 @@
+import { FC, useCallback, useRef } from 'react';
+import styled, { css } from 'styled-components';
+import dayjs from 'dayjs';
+import { Swiper, SwiperProps, SwiperSlide } from 'swiper/react';
+import { Swiper as SwiperClass } from 'swiper/types';
+import { isBoolean } from '@fxts/core';
+
+import SlideButton from 'components/Button/SlideButton';
+import ViewMoreButton from 'components/Button/ViewMoreButton';
+import { BannerInfo } from 'models/display';
+import { getLinkTarget } from 'utils/html';
+import media from 'utils/styles/media';
+
+interface MainSlideProps {
+    settings: SwiperProps;
+    banners: BannerInfo[];
+}
+
+const SlideWrapper = styled.div<{ imgUrl?: string }>`
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    padding-top: 100px;
+    padding-bottom: 120px;
+
+    ${(props) =>
+        props.imgUrl &&
+        css`
+            background-image: url('${props.imgUrl}');
+            background-repeat: no-repeat;
+            background-size: cover;
+            background-position: center;
+        `}
+`;
+
+const NewTitle = styled.span`
+    display: block;
+    font-size: 16px;
+    line-height: 19px;
+    color: ${(props) => props.theme.primary};
+    letter-spacing: 0;
+    margin-bottom: 28px;
+
+    ${media.small} {
+        margin-bottom: 16px;
+    }
+`;
+
+const SlideBannerTitle = styled.h1<{ color: string }>`
+    font-size: 26px;
+    line-height: 32px;
+    color: ${(props) => props.color || '#191919'};
+    margin-bottom: 10px;
+    font-weight: bold;
+`;
+
+const SlideBannerDesc = styled.p<{ color: string }>`
+    font-size: 26px;
+    line-height: 32px;
+    letter-spacing: 0;
+    color: ${(props) => props.color || '#191919'};
+    margin-bottom: 20px;
+`;
+
+const PaginationWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    bottom: 120px !important;
+
+    .main-swiper-pagination-bullets {
+        display: block;
+        width: 55px;
+        border: 3px solid #ffffff;
+        opacity: 1;
+    }
+    .main-swiper-pagination-bullets:not(:last-child) {
+        margin-right: 10px;
+    }
+    .swiper-pagination-bullet-active {
+        display: block;
+        width: 55px;
+        border: 3px solid #b12429;
+        opacity: 1;
+    }
+    .swiper-pagination-bullet-active:not(:last-child) {
+        margin-right: 10px;
+    }
+`;
+
+const MainSlideBanner: FC<MainSlideProps> = ({
+    settings,
+    banners,
+}: MainSlideProps) => {
+    const prevElRef = useRef(null);
+    const nextElRef = useRef(null);
+    const paginationRef = useRef(null);
+
+    // TODO: 현재는 배너 등록일자가 1주일 이내인 것만 NEW 노출
+    const isNew = useCallback((startDt: Date) => {
+        const today = dayjs();
+
+        return (
+            dayjs(startDt).isBefore(today) &&
+            dayjs(startDt).isAfter(today.subtract(1, 'week'))
+        );
+    }, []);
+
+    return (
+        <Swiper
+            {...settings}
+            onBeforeInit={(Swiper: SwiperClass) => {
+                if (!isBoolean(Swiper.params.navigation)) {
+                    const navigation = Swiper.params.navigation;
+                    if (navigation) {
+                        navigation.prevEl = prevElRef.current;
+                        navigation.nextEl = nextElRef.current;
+                    }
+                }
+
+                if (!isBoolean(Swiper.params.pagination)) {
+                    const pagination = Swiper.params.pagination;
+                    if (pagination) {
+                        pagination.el = paginationRef.current;
+                    }
+                }
+            }}
+            navigation={{
+                prevEl: prevElRef.current,
+                nextEl: nextElRef.current,
+            }}
+            pagination={{
+                clickable: true,
+                el: paginationRef.current,
+                type: 'bullets',
+                bulletClass: 'main-swiper-pagination-bullets',
+            }}
+        >
+            {banners.map(
+                ({
+                    bannerNo,
+                    imageUrl,
+                    displayStartYmdt,
+                    name,
+                    nameColor,
+                    description,
+                    descriptionColor,
+                    landingUrl,
+                    browerTargetType,
+                }: BannerInfo) => {
+                    return (
+                        <SwiperSlide key={bannerNo}>
+                            <SlideWrapper imgUrl={imageUrl}>
+                                {isNew(displayStartYmdt) && (
+                                    <NewTitle>NEW</NewTitle>
+                                )}
+
+                                <SlideBannerTitle color={nameColor}>
+                                    {name}
+                                </SlideBannerTitle>
+                                <SlideBannerDesc color={descriptionColor}>
+                                    {description}
+                                </SlideBannerDesc>
+                                {landingUrl && (
+                                    <ViewMoreButton
+                                        to={landingUrl}
+                                        target={getLinkTarget(browerTargetType)}
+                                    >
+                                        자세히 보기
+                                    </ViewMoreButton>
+                                )}
+                            </SlideWrapper>
+                        </SwiperSlide>
+                    );
+                },
+            )}
+            <SlideButton slideButtonType='prev' ref={prevElRef} />
+            <SlideButton slideButtonType='next' ref={nextElRef} />
+
+            <PaginationWrapper
+                className='swiper-pagination'
+                ref={paginationRef}
+            />
+        </Swiper>
+    );
+};
+
+export default MainSlideBanner;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ const queryClient = new QueryClient({
         queries: {
             retry: 0,
             useErrorBoundary: true,
+            refetchOnWindowFocus: process.env.NODE_ENV !== 'development',
         },
         mutations: {
             useErrorBoundary: true,

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,0 +1,4 @@
+const getLinkTarget = (target: 'CURRENT' | 'NEW') =>
+    target === 'CURRENT' ? '_self' : '_blank';
+
+export { getLinkTarget };

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,4 +1,21 @@
+import { pipe, reduce } from '@fxts/core';
+
+const STR_DIVISION = Object.freeze({
+    '/': '<br />',
+    '': '',
+});
+
 const getLinkTarget = (target: 'CURRENT' | 'NEW') =>
     target === 'CURRENT' ? '_self' : '_blank';
 
-export { getLinkTarget };
+const breakWord = (
+    words: string,
+    division: keyof typeof STR_DIVISION = '',
+): string => {
+    return pipe(
+        words.split(division),
+        reduce((a, b) => a + STR_DIVISION[division] + b),
+    );
+};
+
+export { getLinkTarget, breakWord };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@fxts/core@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@fxts/core/-/core-0.8.0.tgz#f89a9beb7db1b5ca29ddc26f5343c87723a9b4e1"
-  integrity sha512-OisOCjqknlKb+g7tenOr/hFRL4gZgZa6KsVyDCn2u7vBBXqLwD+bPIXeZDdsc2yRTrtUGq6IWQseIqmAWN3sKw==
+"@fxts/core@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@fxts/core/-/core-0.9.0.tgz#333441607b31135794d739a1bc54b90d2c85837f"
+  integrity sha512-7s89fPUXcqe5YXGARUr+pa3D+xXExJRPoS/SWzO0zMm/UaRkZIubelNCJZ+sKxoH4vAZpvKd00r/Vs27NHYBAQ==
   dependencies:
     tslib "^2.4.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6231,7 +6231,7 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2:
+deepmerge@^4.0.0, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -9724,6 +9724,11 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -10026,7 +10031,7 @@ memfs@^3.1.2, memfs@^3.2.2, memfs@^3.4.3:
   dependencies:
     fs-monkey "1.0.3"
 
-memoize-one@^5.0.0:
+memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -12147,7 +12152,7 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-fast-compare@^3.2.0:
+react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -12216,6 +12221,17 @@ react-merge-refs@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
+react-player@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.10.1.tgz#f2ee3ec31393d7042f727737545414b951ffc7e4"
+  integrity sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==
+  dependencies:
+    deepmerge "^4.0.0"
+    load-script "^1.0.0"
+    memoize-one "^5.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
 
 react-query@*, react-query@^3.39.0:
   version "3.39.1"


### PR DESCRIPTION
- 메인 슬라이드 배너 추가 (최상단)
  - 자세히보기 버튼 구현(버튼처럼 보이지만 실제로는 Link Component를 이용하여 구현)
  - 자세히보기 버튼 스토리북 작성
  - 슬라이드배너에서 쓰일 좌우 버튼 구헌(prev / next)
  - 슬라이드배너 좌우 버튼 스토리북 작성

- 메인 기타 섹션 추가 (최하단)
  - 메인페이지 > 메인배너 영억의 5번째 구좌(ETC)활용
  - 짝수개로 등록해야함
  - 구좌 우측에 사이즈로 크기 조절 가능
  - banners 배열이 정렬이 되지 않은 상태이므로 displayOrder로 정렬 후 노출