### PR TITLE
:sparkles: feat: 주문 완료 페이지 작성

### DIFF
--- a/src/api/order/myOrder.ts
+++ b/src/api/order/myOrder.ts
@@ -2,7 +2,10 @@ import { AxiosResponse } from 'axios';
 
 import request, { defaultHeaders } from 'api/core';
 import { CLAIM_TYPE, ORDER_REQUEST_TYPE } from 'models';
-import { DeliveryBody, ReceiptBody } from 'models/order';
+import { DeliveryBody, OrderDetailResponse, ReceiptBody } from 'models/order';
+import { tokenStorage } from 'utils/storage';
+
+const accessTokenInfo = tokenStorage.getAccessToken();
 
 const myOrder = {
     // TODO 500 error
@@ -27,7 +30,7 @@ const myOrder = {
                 endYmd,
             },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
     // TODO orderNo가 포함 된 함수들은 테스트 x
@@ -38,16 +41,31 @@ const myOrder = {
         }: {
             orderRequestTypes?: Exclude<
                 keyof typeof ORDER_REQUEST_TYPE,
-                'ALL' | 'CLAIM' | 'NORMAL'
+                | 'DEPOSIT_WAIT'
+                | 'PAY_DONE'
+                | 'PRODUCT_PREPARE'
+                | 'DELIVERY_PREPARE'
+                | 'DELIVERY_ING'
+                | 'DELIVERY_DONE'
+                | 'BUY_CONFIRM'
+                | 'CANCEL_DONE'
+                | 'RETURN_DONE'
+                | 'EXCHANGE_DONE'
+                | 'PAY_WAIT'
+                | 'PAY_CANCEL'
+                | 'PAY_FAIL'
+                | 'DELETE'
+                | 'EXCHANGE_WAIT'
+                | 'REFUND_DONE'
             >;
         },
-    ): Promise<AxiosResponse> =>
+    ): Promise<AxiosResponse<OrderDetailResponse>> =>
         request({
             method: 'GET',
             url: `/profile/orders/${orderNo}`,
             params: { orderRequestTypes },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -60,7 +78,7 @@ const myOrder = {
             url: '/profile/order-options/summary/status',
             params: { startYmd, endYmd },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -69,7 +87,7 @@ const myOrder = {
             method: 'PUT',
             url: `/profile/order-options/${orderOptionNo}/confirm`,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -78,7 +96,7 @@ const myOrder = {
             method: 'PUT',
             url: `/profile/order-options/${orderOptionNo}/delivery-done`,
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -97,7 +115,7 @@ const myOrder = {
             url: '/profile/orders/summary/amount',
             params: { orderStatusType, startYmd, endYmd },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -106,7 +124,7 @@ const myOrder = {
             method: 'GET',
             url: '/profile/orders/summary/status',
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -119,7 +137,7 @@ const myOrder = {
             url: `/profile/orders/${orderNo}/cashReceipt`,
             data: { cashReceiptKey, cashReceiptIssuePurposeType },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -135,7 +153,7 @@ const myOrder = {
             url: `/profile/orders/${orderNo}/claim`,
             params: { orderRequestType, claimType },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 
@@ -170,7 +188,7 @@ const myOrder = {
                 deliveryMemo,
             },
             headers: Object.assign({}, defaultHeaders(), {
-                accessToken: localStorage.getItem('accessToken') || '',
+                accessToken: accessTokenInfo?.accessToken || '',
             }),
         }),
 };

--- a/src/components/Cart/CartList.tsx
+++ b/src/components/Cart/CartList.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as UnChecked } from 'assets/icons/checkbox_square.svg';
 const CartListBox = styled.div`
     display: flex;
     justify-content: space-between;
-    padding: 12px 0;
+    padding: 11px 0;
     height: 164px;
     border-bottom: 1px solid #dbdbdb;
     &:last-child {
@@ -27,10 +27,12 @@ const CartInformation = styled.div`
 const CartImage = styled.div`
     background: #f8f8fa;
     width: 50%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     > img {
-        display: block;
-        width: 60%;
-        margin: 0 auto;
+        width: 63%;
     }
 `;
 
@@ -220,24 +222,15 @@ const CartList = ({
             <CartPrice>
                 <p>
                     <span>
-                        {currency(
-                            cartData.price.salePrice + cartData.price.addPrice,
-                            {
-                                symbol: '',
-                                precision: 0,
-                            },
-                        ).format()}
-                    </span>
-                    {currency(
-                        cartData.price.salePrice +
-                            cartData.price.addPrice -
-                            cartData.price.immediateDiscountAmt -
-                            cartData.price.additionalDiscountAmt,
-                        {
+                        {currency(cartData.price.standardAmt, {
                             symbol: '',
                             precision: 0,
-                        },
-                    ).format()}{' '}
+                        }).format()}
+                    </span>
+                    {currency(cartData.price.buyAmt, {
+                        symbol: '',
+                        precision: 0,
+                    }).format()}{' '}
                     원
                 </p>
             </CartPrice>
@@ -249,7 +242,7 @@ const CartList = ({
                 원
             </CartDelivery>
             <CartAmount>
-                {currency(cartData.price.buyAmt, {
+                {currency(cartData.price.buyAmt + cartData.deliveryAmt, {
                     symbol: '',
                     precision: 0,
                 }).format()}

--- a/src/models/order/index.ts
+++ b/src/models/order/index.ts
@@ -289,7 +289,7 @@ export interface OrderProductOption {
     productNo: number;
     optionNo: number;
     optionInputs: OptionInputs[];
-    validInfo: ValidInfo;
+    validInfo?: ValidInfo;
     reservation: boolean;
     reservationDeliveryYmdt: string;
     setOptions: SetOption[];
@@ -710,4 +710,469 @@ export interface CartCoupon {
     selected: boolean;
     used: boolean;
     couponDiscountAmt: number;
+}
+
+export interface OrderDetailResponse {
+    orderNo: string;
+    orderYmdt: string;
+    payType: string;
+    payInfo: PayInfo;
+    pgType: string;
+    pgMallKey: string;
+    pgOrderNo: string;
+    escrow: boolean;
+    orderMemo: string;
+    orderOptionsGroupByPartner: OrderOptionsGroupByPartner[];
+    guestToken: any;
+    refundInfos: RefundInfo[];
+    additionalPayInfos: AdditionalPayInfo[];
+    exchangePayInfos: ExchangePayInfo[];
+    member: boolean;
+    firstOrderAmount: FirstOrderAmount;
+    lastOrderAmount: LastOrderAmount;
+    shippingAddress: ShippingAddress;
+    orderer: Orderer;
+    billingAddress: any;
+    nextActions: NextAction2[];
+    receiptInfos: ReceiptInfo[];
+    claimReasonTypes: ClaimReasonType[];
+    refundType: string;
+    refundPayType: string;
+    refundTypeLabel: string;
+    memo: string;
+    deliveryMemo: string;
+    extraData: ExtraData;
+    insurance: Insurance;
+    availableBanks: AvailableBank[];
+    requireCustomsIdNumber: boolean;
+    defaultOrderStatusType: string;
+    payTypeLabel: string;
+    accumulationAmtWhenBuyConfirm: number;
+}
+
+export interface PayInfo {
+    payType: string;
+    cardInfo: any;
+    bankInfo: BankInfo;
+    naverPayInfo: any;
+    cashAuthNo: any;
+    cashNo: any;
+    tradeNo: any;
+    escrowYn: string;
+    payAmt: number;
+    sellerCouponAmt: number;
+    pgCouponAmt: number;
+    cardCouponAmt: number;
+    pointAmt: number;
+    taxType: any;
+    mobileInfo: any;
+}
+
+export interface BankInfo {
+    bank: string;
+    bankCode: string;
+    bankName: string;
+    account: string;
+    bankAmt: number;
+    depositAmt: number;
+    depositYmdt: string;
+    remitterName: string;
+    depositorName: string;
+    paymentExpirationYmdt: string;
+}
+
+export interface OrderOptionsGroupByPartner {
+    partnerNo: number;
+    partnerName: string;
+    orderOptionsGroupByDelivery: OrderOptionsGroupByDelivery[];
+}
+
+export interface OrderOptionsGroupByDelivery {
+    deliveryNo: number;
+    deliveryAmt: number;
+    remoteDeliveryAmt: number;
+    returnDeliveryAmt: number;
+    deliveryType: string;
+    deliveryCompanyType: string;
+    invoiceNo: string;
+    deliveryPayType: string;
+    deliveryMemo: any;
+    retrieveInvoiceUrl: string;
+    orderOptions: OrderOption[];
+    receiverName: string;
+    receiverContact1: string;
+    receiverContact2: string;
+    receiverAddress: string;
+    receiverZipCd: string;
+    receiverDetailAddress: string;
+    receiverJibunAddress: any;
+    requestShippingDate: any;
+    usesShippingInfoLaterInput: boolean;
+    shippingAreaType: string;
+    partnerNo: number;
+    partnerName: string;
+    shippingMethodType: any;
+    shippingMethodLabel: any;
+    frontDisplayText: any;
+    deliveryCompanyTypeLabel: string;
+}
+
+export interface OrderOption {
+    orderNo: string;
+    orderOptionNo: number;
+    productNo: number;
+    partnerName: string;
+    optionNo: number;
+    additionalProductNo: number;
+    imageUrl: string;
+    brandNo: number;
+    brandName: string;
+    brandNameEn: string;
+    productName: string;
+    productNameEn: string;
+    optionName: string;
+    optionValue: string;
+    optionUsed: boolean;
+    optionType: string;
+    orderCnt: number;
+    orderStatusType: string;
+    claimStatusType: any;
+    orderStatusDate: OrderStatusDate;
+    claimNo: any;
+    accumulationAmt: number;
+    refundable: boolean;
+    deliveryInternationalYn: boolean;
+    reservationDeliveryYmdt: any;
+    exchangeYn: string;
+    member: boolean;
+    deliverable: boolean;
+    inputs: any[];
+    nextActions: NextAction[];
+    optionManagementCd: string;
+    delivery: Delivery;
+    price: Price;
+    reservation: boolean;
+    isFreeGift: boolean;
+    setOptions: SetOption[];
+    isRecurringPayment: boolean;
+    holdDelivery: boolean;
+    optionTitle: string;
+    orderStatusTypeLabel: string;
+    claimStatusTypeLabel: any;
+}
+
+export interface OrderStatusDate {
+    registerYmdt: string;
+    buyConfirmYmdt: any;
+    reviewableYmdt: any;
+    payYmdt: any;
+}
+
+export interface NextAction {
+    nextActionType: string;
+    uri: string;
+    actionGroupType: string;
+}
+
+export interface Delivery {
+    invoiceNo: any;
+    deliveryCompanyType: any;
+    retrieveInvoiceUrl: any;
+    deliveryType: string;
+    usesShippingInfoLaterInput: boolean;
+    deliveryCompanyTypeLabel: any;
+}
+
+export interface Price {
+    standardPrice: number;
+    immediateDiscountedPrice: number;
+    buyPrice: number;
+    standardAmt: number;
+    immediateDiscountedAmt: number;
+    buyAmt: number;
+    salePrice: number;
+    addPrice: number;
+    immediateDiscountAmt: number;
+    additionalDiscountAmt: number;
+    accumulationRate: number;
+}
+
+export interface SetOption {
+    mallProductNo: number;
+    productManagementCd: string;
+    productName: string;
+    mallOptionNo: number;
+    optionManagementCd: string;
+    optionName: string;
+    optionValue: string;
+    usesOption: boolean;
+    count: number;
+    optionPrice: number;
+    stockNo: number;
+    sku: string;
+    optionNameForDisplay: string;
+}
+
+export interface RefundInfo {
+    claimNo: number;
+    productAmtInfo: ProductAmtInfo;
+    deliveryAmtInfo: DeliveryAmtInfo;
+    subtractionAmtInfo: SubtractionAmtInfo;
+    returnWayType: string;
+    returnAddress: ReturnAddress;
+    returnInvoiceNo: any;
+    returnDeliveryCompanyTypeLabel: any;
+    exchangeAddress: ExchangeAddress;
+    claimImageUrls: any[];
+    exchangeOrderOption: any;
+    claimClassType: any;
+    refundBankAccount: RefundBankAccount;
+    refundPayAmt: number;
+    refundSubPayAmt: number;
+    refundType: string;
+    refundPayType: string;
+    refundTypeLabel: string;
+    refundMainPayAmt: number;
+}
+
+export interface ProductAmtInfo {
+    immediateDiscountedPrice: number;
+    discountAmt: number;
+    standardPrice: number;
+    immediateDiscountAmt: number;
+    additionalDiscountAmt: number;
+    productCouponDiscountAmt: number;
+    exchangeImmediateDiscountedPrice: number;
+    returnImmediateDiscountedPrice: number;
+    exchangeDiscountAmt: number;
+    exchangeAdjustAmt: number;
+    totalAmt: number;
+}
+
+export interface DeliveryAmtInfo {
+    beforeDeliveryAmt: number;
+    afterDeliveryAmt: number;
+    refundDeliveryAmt: number;
+    payOnDelivery: boolean;
+    sellerFault: boolean;
+    returnDeliveryAmt: number;
+    returnAdjustAmt: number;
+    buyerReturn: boolean;
+    exchangeDeliveryAmt: number;
+    exchangeAdjustAmt: number;
+    totalAmt: number;
+}
+
+export interface SubtractionAmtInfo {
+    cartCouponAmt: number;
+    deliveryCouponAmt: number;
+    refundAdjustAmt: number;
+    refundAdjustReason: string;
+    totalAmt: number;
+}
+
+export interface ReturnAddress {
+    name: string;
+    contact1: string;
+    contact2: any;
+    zipCd: string;
+    address: string;
+    jibunAddress: string;
+    detailAddress: string;
+    note: string;
+    addressStr: string;
+    customsIdNumber: any;
+}
+
+export interface ExchangeAddress {
+    name: string;
+    contact1: string;
+    contact2: any;
+    zipCd: string;
+    address: string;
+    jibunAddress: string;
+    detailAddress: string;
+    note: string;
+    addressStr: string;
+    customsIdNumber: any;
+}
+
+export interface RefundBankAccount {
+    bank: string;
+    bankAccount: string;
+    bankDepositorName: string;
+    bankName: string;
+}
+
+export interface AdditionalPayInfo {
+    claimNo: number;
+    productAmtInfo: ProductAmtInfo2;
+    deliveryAmtInfo: DeliveryAmtInfo2;
+    subtractionAmtInfo: SubtractionAmtInfo2;
+    returnWayType: any;
+    returnAddress: ReturnAddress2;
+    returnInvoiceNo: any;
+    returnDeliveryCompanyTypeLabel: any;
+    exchangeAddress: ExchangeAddress2;
+    claimImageUrls: any[];
+    exchangeOrderOption: any;
+    claimClassType: any;
+    bankAccount: BankAccount;
+    remitter: string;
+    payType: string;
+    exchangePayAmt: number;
+}
+
+export interface ProductAmtInfo2 {
+    immediateDiscountedPrice: number;
+    discountAmt: number;
+    standardPrice: number;
+    immediateDiscountAmt: number;
+    additionalDiscountAmt: number;
+    productCouponDiscountAmt: number;
+    exchangeImmediateDiscountedPrice: number;
+    returnImmediateDiscountedPrice: number;
+    exchangeDiscountAmt: number;
+    exchangeAdjustAmt: number;
+    totalAmt: number;
+}
+
+export interface DeliveryAmtInfo2 {
+    beforeDeliveryAmt: number;
+    afterDeliveryAmt: number;
+    refundDeliveryAmt: number;
+    payOnDelivery: boolean;
+    sellerFault: boolean;
+    returnDeliveryAmt: number;
+    returnAdjustAmt: number;
+    buyerReturn: boolean;
+    exchangeDeliveryAmt: number;
+    exchangeAdjustAmt: number;
+    totalAmt: number;
+}
+
+export interface SubtractionAmtInfo2 {
+    cartCouponAmt: number;
+    deliveryCouponAmt: number;
+    refundAdjustAmt: number;
+    refundAdjustReason: string;
+    totalAmt: number;
+}
+
+export interface ReturnAddress2 {
+    name: string;
+    contact1: string;
+    contact2: any;
+    zipCd: string;
+    address: string;
+    jibunAddress: string;
+    detailAddress: string;
+    note: string;
+    addressStr: string;
+    customsIdNumber: any;
+}
+
+export interface ExchangeAddress2 {
+    name: string;
+    contact1: string;
+    contact2: any;
+    zipCd: string;
+    address: string;
+    jibunAddress: string;
+    detailAddress: string;
+    note: string;
+    addressStr: string;
+    customsIdNumber: any;
+}
+
+export interface BankAccount {
+    bank: string;
+    bankAccount: string;
+    bankDepositorName: string;
+    bankName: string;
+}
+
+export interface ExchangePayInfo {
+    exchangePayAmt: number;
+    payType: string;
+    bankAccount: BankAccount2;
+    remitter: string;
+}
+
+export interface BankAccount2 {
+    bank: string;
+    bankAccount: string;
+    bankDepositorName: string;
+    bankName: string;
+}
+
+export interface FirstOrderAmount {
+    payAmt: number;
+    subPayAmt: number;
+    standardAmt: number;
+    deliveryAmt: number;
+    remoteDeliveryAmt: number;
+    immediateDiscountAmt: number;
+    additionalDiscountAmt: number;
+    cartCouponDiscountAmt: number;
+    productCouponDiscountAmt: number;
+    deliveryCouponDiscountAmt: number;
+    totalProductAmt: number;
+    chargeAmt: number;
+}
+
+export interface LastOrderAmount {
+    payAmt: number;
+    subPayAmt: number;
+    standardAmt: number;
+    deliveryAmt: number;
+    remoteDeliveryAmt: number;
+    immediateDiscountAmt: number;
+    additionalDiscountAmt: number;
+    cartCouponDiscountAmt: number;
+    productCouponDiscountAmt: number;
+    deliveryCouponDiscountAmt: number;
+    totalProductAmt: number;
+    chargeAmt: number;
+}
+
+export interface ShippingAddress {
+    addressNo: number;
+    receiverZipCd: string;
+    receiverAddress: string;
+    receiverJibunAddress: string;
+    receiverDetailAddress: string;
+    receiverName: string;
+    addressName: any;
+    receiverContact1: string;
+    receiverContact2: any;
+    customsIdNumber: any;
+    countryCd: string;
+}
+
+export interface NextAction2 {
+    nextActionType: string;
+    uri: string;
+    actionGroupType: string;
+}
+
+export interface ReceiptInfo {
+    receiptType: string;
+    url: string;
+}
+
+export interface ClaimReasonType {
+    claimReasonType: string;
+    label: string;
+    responsibleObjectType: string;
+}
+export interface Insurance {
+    no: any;
+    type: any;
+    url: any;
+}
+
+export interface AvailableBank {
+    bank: string;
+    label: string;
 }

--- a/src/pages/Order/Complete.tsx
+++ b/src/pages/Order/Complete.tsx
@@ -629,7 +629,7 @@ const Complete = () => {
                             >
                                 주문 내역 보기
                             </OrderListButton>
-                            <ContinueShoppingButton to={'/'}>
+                            <ContinueShoppingButton to={PATHS.MAIN}>
                                 쇼핑 계속하기
                             </ContinueShoppingButton>
                         </ButtonWrapper>

--- a/src/pages/Order/Complete.tsx
+++ b/src/pages/Order/Complete.tsx
@@ -1,0 +1,661 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from 'react-query';
+import { shallowEqual } from 'react-redux';
+import styled from 'styled-components';
+import currency from 'currency.js';
+import dayjs from 'dayjs';
+import { head, join, pipe, split } from '@fxts/core';
+
+import { useTypedSelector } from 'state/reducers';
+import { myOrder } from 'api/order';
+import { ORDER_REQUEST_TYPE } from 'models';
+import { OrderOptionsGroupByDelivery, OrderProductOption } from 'models/order';
+import PATHS from 'const/paths';
+import LayoutResponsive from 'components/shared/LayoutResponsive';
+import CartList from 'components/Cart/CartList';
+import SEOHelmet from 'components/shared/SEOHelmet';
+import Header from 'components/shared/Header';
+
+const CompleteContainer = styled.div`
+    padding: 0 40px;
+`;
+
+const Progress = styled.div`
+    display: flex;
+    color: #ababab;
+    font-weight: bold;
+    font-size: 24px;
+    .current-progress {
+        color: ${(props) => props.theme.text1};
+    }
+    > div {
+        margin-right: 18px;
+    }
+`;
+
+const OrderNoContainer = styled.div`
+    width: 100%;
+    height: 340px;
+    background-color: ${(props) => props.theme.bg2};
+    margin: 48px 0 70px;
+    padding-top: 101px;
+    > p {
+        font-weight: bold;
+        font-size: 30px;
+        color: ${(props) => props.theme.text1};
+    }
+`;
+
+const PayType = styled.div`
+    display: inline-block;
+    padding: 6px 11px;
+    border: 1px solid #8c909d;
+    margin: 30px 0 10px;
+    color: #767676;
+    font-size: 12px;
+`;
+
+const DepositDeadline = styled.div`
+    font: 16px;
+    letter-spacing: -0.64px;
+    color: #8f8f8f;
+    margin-bottom: 10px;
+    > span {
+        font-weight: bold;
+        color: ${(props) => props.theme.text1};
+    }
+`;
+
+const OrderNoBox = styled.div`
+    font-size: 16px;
+    color: #767676;
+`;
+
+const OrderInformationContainer = styled.div``;
+
+const OrderInformationBox = styled.div`
+    font-size: 16px;
+    margin-bottom: 64px;
+`;
+
+const OrderInformationTitle = styled.div`
+    text-align: left;
+    color: ${(props) => props.theme.text1};
+    font-size: 24px;
+    font-weight: bold;
+    letter-spacing: -1.2px;
+    padding-bottom: 24px;
+    border-bottom: 2px solid #222943;
+    margin-bottom: 40px;
+`;
+
+const OrderInformationPrice = styled.div<{ marginBottom: string }>`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    text-align: left;
+    margin-bottom: ${(props) => props.marginBottom};
+    color: ${(props) => props.theme.text1};
+    font-weight: bold;
+`;
+
+const OrderInformationList = styled.div<{ marginBottom: string }>`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    text-align: right;
+    margin-bottom: ${(props) => props.marginBottom};
+    color: #767676;
+`;
+
+const OrderInformationCategory = styled.div`
+    letter-spacing: -0.64px;
+`;
+
+const OrderInformationContent = styled.div`
+    letter-spacing: 0;
+    p {
+        margin-top: 12px;
+    }
+`;
+
+const ButtonWrapper = styled.div`
+    font-size: 16px;
+    letter-spacing: -0.64px;
+    line-height: 44px;
+    display: flex;
+    width: fit-content;
+    margin: 0 auto;
+`;
+
+const OrderListButton = styled(Link)`
+    display: block;
+    color: ${(props) => props.theme.text1};
+    border: ${(props) => `1px solid ${props.theme.line2}`};
+    width: 210px;
+    height: 44px;
+    margin-right: 21px;
+`;
+
+const ContinueShoppingButton = styled(Link)`
+    display: block;
+    background: #222943;
+    color: #fff;
+    width: 210px;
+    height: 44px;
+`;
+
+const OrderProductListBox = styled.div`
+    margin-top: 91px;
+    border-top: 2px solid #222943;
+    border-bottom: 2px solid #222943;
+`;
+
+const CartCategoryBox = styled.div`
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px solid #dbdbdb;
+    > div {
+        padding: 20px 0;
+        text-align: center;
+        color: #191919;
+        font-size: 16px;
+        font-weight: bold;
+    }
+`;
+
+const CartInformation = styled.div`
+    width: 240px;
+    display: flex;
+    justify-content: space-around;
+`;
+
+const CartCountBox = styled.div`
+    width: 150px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    > div {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border: ${(props) => `1px solid ${props.theme.line2}`};
+        width: 78px;
+        > div {
+            width: 26px;
+            text-align: center;
+            height: 30px;
+            line-height: 30px;
+        }
+    }
+`;
+
+const CartPrice = styled.div`
+    width: 140px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    > p {
+        font-size: 16px;
+        color: #191919;
+        position: relative;
+        > span {
+            display: block;
+            position: absolute;
+            bottom: 100%;
+            text-decoration: line-through;
+            font-size: 12px;
+            color: #ababab;
+        }
+    }
+`;
+
+const CartDelivery = styled.div`
+    width: 140px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #191919;
+    font: 16px;
+`;
+
+const CartAmount = styled.div`
+    width: 200px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+    > span {
+        font-weight: 400;
+    }
+`;
+
+const Complete = () => {
+    const [orderList, setOrderList] =
+        useState<
+            Array<
+                OrderProductOption & {
+                    deliveryAmt: number;
+                    productName: string;
+                }
+            >
+        >();
+    const [deliveryInfo, setDeliveryInfo] =
+        useState<OrderOptionsGroupByDelivery>();
+
+    const orderParam = useMemo(
+        () => new URLSearchParams(window.location.search),
+        [],
+    );
+
+    const { member } = useTypedSelector(
+        ({ member }) => ({
+            member: member.data,
+        }),
+        shallowEqual,
+    );
+
+    const { data: orderCompleteData } = useQuery(
+        ['orderCompleteData', { member: member?.memberName }],
+        async () =>
+            await myOrder.getOrderDetail(orderParam.get('orderNo')!, {
+                orderRequestTypes: ORDER_REQUEST_TYPE.ALL,
+            }),
+        {
+            onSuccess: (res) => {
+                const newOrderList: Array<
+                    OrderProductOption & {
+                        deliveryAmt: number;
+                        productName: string;
+                    }
+                > = [];
+                res.data.orderOptionsGroupByPartner.forEach(
+                    (partnerOptionGroup) => {
+                        partnerOptionGroup.orderOptionsGroupByDelivery.forEach(
+                            (deliveryOptionGroup) => {
+                                deliveryOptionGroup.orderOptions.forEach(
+                                    ({
+                                        accumulationAmt,
+                                        optionNo,
+                                        imageUrl,
+                                        optionManagementCd,
+                                        optionName,
+                                        orderOptionNo,
+                                        optionTitle,
+                                        optionType,
+                                        optionValue,
+                                        orderCnt,
+                                        price,
+                                        productName,
+                                        productNo,
+                                        reservation,
+                                        reservationDeliveryYmdt,
+                                        setOptions,
+                                        inputs,
+                                    }) => {
+                                        newOrderList.push({
+                                            accumulationAmtWhenBuyConfirm:
+                                                accumulationAmt,
+                                            cartNo: optionNo,
+                                            deliveryAmt:
+                                                deliveryOptionGroup.deliveryAmt,
+                                            imageUrl,
+                                            optionInputs: inputs,
+                                            optionManagementCd,
+                                            optionName,
+                                            optionNo: orderOptionNo,
+                                            optionTitle,
+                                            optionType,
+                                            optionValue,
+                                            orderCnt,
+                                            price,
+                                            productName,
+                                            productNo,
+                                            recurringDeliveryCycles: null,
+                                            reservation,
+                                            reservationDeliveryYmdt,
+                                            setOptions,
+                                            soldOut: false,
+                                            stockCnt: 999999,
+                                        });
+                                    },
+                                );
+                            },
+                        );
+                    },
+                );
+                setOrderList([...newOrderList]);
+                setDeliveryInfo(
+                    head(
+                        head(res.data.orderOptionsGroupByPartner)!
+                            .orderOptionsGroupByDelivery,
+                    ),
+                );
+            },
+            refetchOnWindowFocus: false,
+            enabled: !!orderParam.get('orderNo'),
+        },
+    );
+
+    const payTypeText = () => {
+        let payType = '';
+        switch (orderCompleteData?.data.payType) {
+            case 'ACCOUNT':
+                payType = '무통장 입금';
+                break;
+            case 'CREDIT_CARD':
+                payType = '신용카드';
+                break;
+            case 'REALTIME_ACCOUNT_TRANSFER':
+                payType = '실시간 계좌 이체';
+                break;
+            case 'VIRTUAL_ACCOUNT':
+                payType = '가상계좌';
+                break;
+            case 'KPAY':
+                payType = 'KPAY';
+                break;
+        }
+        return payType;
+    };
+
+    return (
+        <>
+            <SEOHelmet
+                data={{
+                    title: '주문 완료',
+                }}
+            />
+            <Header />
+            <LayoutResponsive type='medium' style={{ padding: '10rem 0' }}>
+                {orderCompleteData && (
+                    <CompleteContainer>
+                        <Progress>
+                            <div>주문서</div>
+                            <div>&#8250;</div>
+                            <div className='current-progress'>주문 완료</div>
+                        </Progress>
+                        <OrderNoContainer>
+                            <p>주문이 완료되었습니다 !</p>
+                            <PayType>{payTypeText()}</PayType>
+                            <DepositDeadline>
+                                <span>
+                                    {dayjs(
+                                        orderCompleteData.data.payInfo.bankInfo
+                                            .paymentExpirationYmdt,
+                                    ).format('YY.MM.DD')}{' '}
+                                    까지 계좌로 입금
+                                </span>
+                                해주시면 제품이 발송됩니다.
+                            </DepositDeadline>
+                            <OrderNoBox>
+                                주문번호 {orderParam.get('orderNo')}
+                            </OrderNoBox>
+                        </OrderNoContainer>
+                        <OrderInformationContainer>
+                            {orderCompleteData.data.payType ===
+                                ('ACCOUNT' ||
+                                    'REALTIME_ACCOUNT_TRANSFER' ||
+                                    'VIRTUAL_ACCOUNT') && (
+                                <OrderInformationBox>
+                                    <OrderInformationTitle>
+                                        이체 정보
+                                    </OrderInformationTitle>
+                                    <OrderInformationPrice marginBottom='60px'>
+                                        <OrderInformationCategory>
+                                            <div>이체 금액</div>
+                                        </OrderInformationCategory>
+                                        <OrderInformationContent>
+                                            <div>
+                                                {currency(
+                                                    orderCompleteData.data
+                                                        .payInfo.payAmt,
+                                                    {
+                                                        symbol: '',
+                                                        precision: 0,
+                                                    },
+                                                ).format()}{' '}
+                                                원
+                                            </div>
+                                        </OrderInformationContent>
+                                    </OrderInformationPrice>
+                                    <OrderInformationList marginBottom='32px'>
+                                        <OrderInformationCategory>
+                                            <div>계좌정보</div>
+                                        </OrderInformationCategory>
+                                        <OrderInformationContent>
+                                            <div>
+                                                {
+                                                    orderCompleteData.data
+                                                        .payInfo.bankInfo
+                                                        .bankName
+                                                }{' '}
+                                                {
+                                                    orderCompleteData.data
+                                                        .payInfo.bankInfo
+                                                        .account
+                                                }
+                                                <p>
+                                                    {
+                                                        orderCompleteData.data
+                                                            .payInfo.bankInfo
+                                                            .depositorName
+                                                    }
+                                                </p>
+                                            </div>
+                                        </OrderInformationContent>
+                                    </OrderInformationList>
+                                    <OrderInformationList marginBottom='0'>
+                                        <OrderInformationCategory>
+                                            <div>입금기한</div>
+                                        </OrderInformationCategory>
+                                        <OrderInformationContent>
+                                            <div>
+                                                {dayjs(
+                                                    orderCompleteData.data
+                                                        .payInfo.bankInfo
+                                                        .paymentExpirationYmdt,
+                                                ).format(
+                                                    'YY.MM.DD HH:mm:ss',
+                                                )}{' '}
+                                                까지
+                                            </div>
+                                        </OrderInformationContent>
+                                    </OrderInformationList>
+                                </OrderInformationBox>
+                            )}
+                            <OrderInformationBox>
+                                <OrderInformationTitle>
+                                    결제 정보
+                                </OrderInformationTitle>
+                                <OrderInformationPrice marginBottom='24px'>
+                                    <OrderInformationCategory>
+                                        <div>총 결제금액</div>
+                                    </OrderInformationCategory>
+                                    <OrderInformationContent>
+                                        <div>
+                                            {currency(
+                                                orderCompleteData.data.payInfo
+                                                    .payAmt,
+                                                { symbol: '', precision: 0 },
+                                            ).format()}{' '}
+                                            원
+                                        </div>
+                                    </OrderInformationContent>
+                                </OrderInformationPrice>
+                                <OrderInformationList marginBottom='24px'>
+                                    <OrderInformationCategory>
+                                        <div>상품가격</div>
+                                    </OrderInformationCategory>
+                                    <OrderInformationContent>
+                                        <div>
+                                            {currency(
+                                                orderCompleteData?.data
+                                                    .lastOrderAmount
+                                                    .standardAmt,
+                                                { symbol: '', precision: 0 },
+                                            ).format()}{' '}
+                                            원
+                                        </div>
+                                    </OrderInformationContent>
+                                </OrderInformationList>
+                                <OrderInformationList marginBottom='24px'>
+                                    <OrderInformationCategory>
+                                        <div>배송비</div>
+                                    </OrderInformationCategory>
+                                    <OrderInformationContent>
+                                        <div>
+                                            {currency(
+                                                orderCompleteData?.data
+                                                    .lastOrderAmount
+                                                    .deliveryAmt,
+                                                { symbol: '', precision: 0 },
+                                            ).format()}{' '}
+                                            원
+                                        </div>
+                                    </OrderInformationContent>
+                                </OrderInformationList>
+                                <OrderInformationList marginBottom='24px'>
+                                    <OrderInformationCategory>
+                                        <div>할인 금액</div>
+                                    </OrderInformationCategory>
+                                    <OrderInformationContent>
+                                        <div>
+                                            -
+                                            {currency(
+                                                orderCompleteData?.data
+                                                    .lastOrderAmount
+                                                    .immediateDiscountAmt +
+                                                    orderCompleteData?.data
+                                                        .lastOrderAmount
+                                                        .additionalDiscountAmt,
+                                                { symbol: '', precision: 0 },
+                                            ).format()}{' '}
+                                            원
+                                        </div>
+                                    </OrderInformationContent>
+                                </OrderInformationList>
+                                <OrderInformationList marginBottom='24px'>
+                                    <OrderInformationCategory>
+                                        <div>쿠폰 할인</div>
+                                    </OrderInformationCategory>
+                                    <OrderInformationContent>
+                                        <div>
+                                            -
+                                            {currency(
+                                                orderCompleteData?.data
+                                                    .lastOrderAmount
+                                                    .cartCouponDiscountAmt +
+                                                    orderCompleteData?.data
+                                                        .lastOrderAmount
+                                                        .productCouponDiscountAmt,
+                                                { symbol: '', precision: 0 },
+                                            ).format()}{' '}
+                                            원
+                                        </div>
+                                    </OrderInformationContent>
+                                </OrderInformationList>
+                                <OrderInformationList marginBottom='0'>
+                                    <OrderInformationCategory>
+                                        <div>적립금 사용</div>
+                                    </OrderInformationCategory>
+                                    <OrderInformationContent>
+                                        <div>
+                                            {orderCompleteData?.data
+                                                .lastOrderAmount.subPayAmt >
+                                                0 && '-'}
+                                            {currency(
+                                                orderCompleteData?.data
+                                                    .lastOrderAmount.subPayAmt,
+                                                { symbol: '', precision: 0 },
+                                            ).format()}{' '}
+                                            원
+                                        </div>
+                                    </OrderInformationContent>
+                                </OrderInformationList>
+                            </OrderInformationBox>
+                            {deliveryInfo && (
+                                <OrderInformationBox>
+                                    <OrderInformationTitle>
+                                        배송 정보
+                                    </OrderInformationTitle>
+                                    <OrderInformationList marginBottom='28px'>
+                                        <OrderInformationCategory>
+                                            <div>받는사람</div>
+                                        </OrderInformationCategory>
+                                        <OrderInformationContent>
+                                            <div>
+                                                {deliveryInfo.receiverName}
+                                            </div>
+                                        </OrderInformationContent>
+                                    </OrderInformationList>
+                                    <OrderInformationList marginBottom='28px'>
+                                        <OrderInformationCategory>
+                                            <div>주소</div>
+                                        </OrderInformationCategory>
+                                        <OrderInformationContent>
+                                            <div>
+                                                {deliveryInfo.receiverAddress}
+                                                {
+                                                    deliveryInfo.receiverDetailAddress
+                                                }
+                                            </div>
+                                        </OrderInformationContent>
+                                    </OrderInformationList>
+                                    <OrderInformationList marginBottom='0'>
+                                        <OrderInformationCategory>
+                                            <div>전화번호</div>
+                                        </OrderInformationCategory>
+                                        <OrderInformationContent>
+                                            <div>
+                                                {pipe(
+                                                    deliveryInfo.receiverContact1,
+                                                    split('-'),
+                                                    join(''),
+                                                )}
+                                            </div>
+                                        </OrderInformationContent>
+                                    </OrderInformationList>
+                                </OrderInformationBox>
+                            )}
+                        </OrderInformationContainer>
+                        <ButtonWrapper>
+                            <OrderListButton
+                                to={
+                                    member ? PATHS.MY_ORDER_LIST : PATHS.MY_PAGE
+                                }
+                            >
+                                주문 내역 보기
+                            </OrderListButton>
+                            <ContinueShoppingButton to={'/'}>
+                                쇼핑 계속하기
+                            </ContinueShoppingButton>
+                        </ButtonWrapper>
+                        <OrderProductListBox>
+                            <CartCategoryBox>
+                                <CartInformation>상품 정보</CartInformation>
+                                <CartCountBox>수량</CartCountBox>
+                                <CartPrice>가격</CartPrice>
+                                <CartDelivery>배송비</CartDelivery>
+                                <CartAmount>총 상품 금액</CartAmount>
+                            </CartCategoryBox>
+                            {orderList?.map((orderData) => {
+                                return (
+                                    <CartList
+                                        cartData={orderData}
+                                        key={orderData.optionNo}
+                                        isModifiable={false}
+                                    />
+                                );
+                            })}
+                        </OrderProductListBox>
+                    </CompleteContainer>
+                )}
+            </LayoutResponsive>
+        </>
+    );
+};
+
+export default Complete;

--- a/src/router/OrderRouter.tsx
+++ b/src/router/OrderRouter.tsx
@@ -1,11 +1,13 @@
 import { Route, Routes } from 'react-router-dom';
 
 import Sheet from 'pages/Order/Sheet';
+import Complete from 'pages/Order/Complete';
 import NotFound from 'pages/NotFound';
 
 const OrderRouter = () => (
     <Routes>
         <Route path='sheet/:orderSheetNo' element={<Sheet />} />
+        <Route path='complete' element={<Complete />} />
         <Route path='*' element={<NotFound />} />
     </Routes>
 );


### PR DESCRIPTION
- Complete 페이지 및 router 추가 
- CartList 컴포넌트 이미지 사이즈 수정 및 출력하는 데이터 변경

## Complete 페이지
- 계좌 이체 및 무통장 입금시 이체 정보(이체 금액, 계좌, 입금 기한 등) 출력
-  수취인 정보는 배열로 들어오지만 수취인 정보는 한 개 뿐이므로 배열의 첫 번째 값을 출력하도록 설정
- 비회원이 주문 내역을 클릭하는 경우 마이페이지 메인으로 이동
- 상품 정보 호출 (CartList 컴포넌트의 데이터 타입을 맞추기 위해 데이터를 각각 넣어줌)
