### PR TITLE
fix: 상품 상세 페이지 alert 표시

### DIFF
--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -34,34 +34,39 @@ const cart = {
     }: Pick<
         ShoppingCartBody,
         'cartNo' | 'orderCnt' | 'optionInputs'
-    >): Promise<AxiosResponse> =>
-        request({
+    >): Promise<AxiosResponse> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'PUT',
             url: '/cart',
             data: [{ orderCnt, cartNo, optionInputs }],
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 
     registerCart: (
         body: Omit<ShoppingCartBody, 'cartNo'>[],
-    ): Promise<AxiosResponse> =>
-        request({
+    ): Promise<AxiosResponse> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'POST',
             url: '/cart',
             data: body,
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 
     deleteCart: ({
         cartNo,
     }: {
         cartNo: number | number[];
-    }): Promise<AxiosResponse> =>
-        request({
+    }): Promise<AxiosResponse> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'DELETE',
             url: '/cart',
             params: { cartNo },
@@ -71,7 +76,8 @@ const cart = {
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 
     getSelectedCartPrice: ({
         cartNo,
@@ -79,8 +85,9 @@ const cart = {
     }: {
         cartNo: number[] | number | null;
         divideInvalidProducts?: boolean;
-    }): Promise<AxiosResponse<CartPrice>> =>
-        request({
+    }): Promise<AxiosResponse<CartPrice>> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'GET',
             url: '/cart/calculate',
             params: { cartNo, divideInvalidProducts },
@@ -92,40 +99,47 @@ const cart = {
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 
-    getCartCount: (): Promise<AxiosResponse> =>
-        request({
+    getCartCount: (): Promise<AxiosResponse> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'GET',
             url: '/cart/count',
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 
     getSelectedCartGroupPrice: ({
         cartNo,
         divideInvalidProducts,
     }: Pick<ShoppingCartBody, 'cartNo'> & {
         divideInvalidProducts?: boolean;
-    }): Promise<AxiosResponse> =>
-        request({
+    }): Promise<AxiosResponse> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'GET',
             url: '/cart/subset',
             params: { cartNo, divideInvalidProducts },
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 
-    checkCartValidation: (): Promise<AxiosResponse> =>
-        request({
+    checkCartValidation: (): Promise<AxiosResponse> => {
+        const accessTokenInfo = tokenStorage.getAccessToken();
+        return request({
             method: 'GET',
             url: '/cart/validate',
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
-        }),
+        });
+    },
 };
 
 export default cart;

--- a/src/api/order/cart.ts
+++ b/src/api/order/cart.ts
@@ -36,6 +36,7 @@ const cart = {
         'cartNo' | 'orderCnt' | 'optionInputs'
     >): Promise<AxiosResponse> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'PUT',
             url: '/cart',
@@ -50,6 +51,7 @@ const cart = {
         body: Omit<ShoppingCartBody, 'cartNo'>[],
     ): Promise<AxiosResponse> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'POST',
             url: '/cart',
@@ -66,6 +68,7 @@ const cart = {
         cartNo: number | number[];
     }): Promise<AxiosResponse> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'DELETE',
             url: '/cart',
@@ -79,23 +82,22 @@ const cart = {
         });
     },
 
-    getSelectedCartPrice: ({
-        cartNo,
-        divideInvalidProducts,
-    }: {
+    getSelectedCartPrice: (params: {
         cartNo: number[] | number | null;
         divideInvalidProducts?: boolean;
     }): Promise<AxiosResponse<CartPrice>> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'GET',
             url: '/cart/calculate',
-            params: { cartNo, divideInvalidProducts },
-            paramsSerializer: (params) => {
-                return typeof params === 'object'
-                    ? qs.stringify(params, { arrayFormat: 'comma' })
-                    : '';
+            params: {
+                cartNo: params.cartNo,
+                divideInvalidProducts: params.divideInvalidProducts,
             },
+            paramsSerializer: (param) =>
+                qs.stringify(param, { arrayFormat: 'comma' }),
+
             headers: Object.assign({}, defaultHeaders(), {
                 accessToken: accessTokenInfo?.accessToken || '',
             }),
@@ -104,6 +106,7 @@ const cart = {
 
     getCartCount: (): Promise<AxiosResponse> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'GET',
             url: '/cart/count',
@@ -120,6 +123,7 @@ const cart = {
         divideInvalidProducts?: boolean;
     }): Promise<AxiosResponse> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'GET',
             url: '/cart/subset',
@@ -132,6 +136,7 @@ const cart = {
 
     checkCartValidation: (): Promise<AxiosResponse> => {
         const accessTokenInfo = tokenStorage.getAccessToken();
+
         return request({
             method: 'GET',
             url: '/cart/validate',

--- a/src/components/Cart/CartList.tsx
+++ b/src/components/Cart/CartList.tsx
@@ -31,6 +31,7 @@ const CartImage = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
     > img {
         width: 63%;
     }
@@ -41,6 +42,9 @@ const CartSelect = styled.div`
         display: none;
     }
     > label {
+        position: absolute;
+        top: 0;
+        left: 0;
     }
 `;
 

--- a/src/components/OrderSheet/OrderSheetPrice.tsx
+++ b/src/components/OrderSheet/OrderSheetPrice.tsx
@@ -63,17 +63,17 @@ const OrderSheetPrice = ({
     amountPrice,
 }: {
     title: string;
-    cartOrderPrice?: Array<Array<string | number | undefined>>;
+    cartOrderPrice?: { name: string; price: number }[];
     amountPrice?: number;
 }) => {
     return (
         <CartOrderBox>
             <CartOrderPriceTitle>{title}</CartOrderPriceTitle>
             <CartOrderPriceBox>
-                {cartOrderPrice?.map(([subTitle, price]: any) => {
+                {cartOrderPrice?.map(({ name, price }) => {
                     return (
-                        <OrderPriceWrapper key={subTitle}>
-                            <CartOrderSubTitle>{subTitle}</CartOrderSubTitle>
+                        <OrderPriceWrapper key={name}>
+                            <CartOrderSubTitle>{name}</CartOrderSubTitle>
                             <CartOrderPrice>
                                 {currency(price, {
                                     symbol: '',

--- a/src/components/OrderSheet/OrderSheetPrice.tsx
+++ b/src/components/OrderSheet/OrderSheetPrice.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import currency from 'currency.js';
+import { OrderPrice } from 'pages/Cart/Cart';
 
 const CartOrderBox = styled.div`
     background: #f8f8fa;
@@ -63,27 +64,28 @@ const OrderSheetPrice = ({
     amountPrice,
 }: {
     title: string;
-    cartOrderPrice?: { name: string; price: number }[];
+    cartOrderPrice?: OrderPrice;
     amountPrice?: number;
 }) => {
     return (
         <CartOrderBox>
             <CartOrderPriceTitle>{title}</CartOrderPriceTitle>
             <CartOrderPriceBox>
-                {cartOrderPrice?.map(({ name, price }) => {
-                    return (
-                        <OrderPriceWrapper key={name}>
-                            <CartOrderSubTitle>{name}</CartOrderSubTitle>
-                            <CartOrderPrice>
-                                {currency(price, {
-                                    symbol: '',
-                                    precision: 0,
-                                }).format()}{' '}
-                                원
-                            </CartOrderPrice>
-                        </OrderPriceWrapper>
-                    );
-                })}
+                {cartOrderPrice &&
+                    Object.values(cartOrderPrice).map(({ name, price }) => {
+                        return (
+                            <OrderPriceWrapper key={name}>
+                                <CartOrderSubTitle>{name}</CartOrderSubTitle>
+                                <CartOrderPrice>
+                                    {currency(price, {
+                                        symbol: '',
+                                        precision: 0,
+                                    }).format()}{' '}
+                                    원
+                                </CartOrderPrice>
+                            </OrderPriceWrapper>
+                        );
+                    })}
             </CartOrderPriceBox>
             <CartOrderPaymentAmount>
                 <CartOrderSubTitle>총 결제금액</CartOrderSubTitle>

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -15,6 +15,13 @@ const useCart = () => {
         shallowEqual,
     );
 
+    const { cart: guestCartList } = useTypedSelector(
+        ({ cart }) => ({
+            cart: cart.data,
+        }),
+        shallowEqual,
+    );
+
     const { data: cartInfo, refetch } = useQuery(
         ['cart', member?.memberId],
         async () => await cart.getCart(),
@@ -38,7 +45,11 @@ const useCart = () => {
         },
     );
 
-    return { cartInfo, totalCount, refetch };
+    return {
+        cartInfo,
+        totalCount: member ? totalCount : guestCartList.length,
+        refetch,
+    };
 };
 
 export default useCart;

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -15,7 +15,7 @@ const useCart = () => {
         shallowEqual,
     );
 
-    const { cart: guestCartList } = useTypedSelector(
+    const { cart: guestCartInfo } = useTypedSelector(
         ({ cart }) => ({
             cart: cart.data,
         }),
@@ -47,7 +47,7 @@ const useCart = () => {
 
     return {
         cartInfo,
-        totalCount: member ? totalCount : guestCartList.length,
+        totalCount: member ? totalCount : guestCartInfo.length,
         refetch,
     };
 };

--- a/src/pages/Order/Sheet.tsx
+++ b/src/pages/Order/Sheet.tsx
@@ -285,6 +285,8 @@ const Sheet = () => {
         >
     >([]);
     const [ordererInformation, setOrdererInformation] = useState(false);
+    const [orderPriceData, setOrderPriceData] =
+        useState<{ name: string; price: number }[]>();
     const [agreePurchase, setAgreePurchase] = useState<string[]>([]);
     const [isShippingListModal, setIsShippingListModal] = useState(false);
     const [isSearchAddressModal, setIsSearchAddressModal] = useState(false);
@@ -345,6 +347,29 @@ const Sheet = () => {
                     });
                     return [...newOrderList];
                 });
+                setOrderPriceData([
+                    {
+                        name: '총 주문금액',
+                        price: res?.data.paymentInfo.totalStandardAmt,
+                    },
+                    {
+                        name: '총 배송비',
+                        price: res?.data.paymentInfo.deliveryAmt,
+                    },
+                    {
+                        name: '총 할인금액',
+                        price:
+                            res?.data.paymentInfo.totalImmediateDiscountAmt +
+                            res?.data.paymentInfo.totalAdditionalDiscountAmt,
+                    },
+                    {
+                        name: '쿠폰 할인',
+                        price:
+                            res?.data.paymentInfo.cartCouponAmt +
+                            +res?.data.paymentInfo.productCouponAmt +
+                            res?.data.paymentInfo.deliveryCouponAmt,
+                    },
+                ]);
             },
             refetchOnWindowFocus: false,
         },
@@ -356,7 +381,7 @@ const Sheet = () => {
             addressNo: getValues('shippingAddress.addressNo')
                 ? getValues('shippingAddress.addressNo')
                 : 0,
-            receiverZipCd: getValues('shippingAddress.receiverZipCd'), // TODO zipCode 입력 하기
+            receiverZipCd: getValues('shippingAddress.receiverZipCd'),
             receiverAddress: getValues('shippingAddress.receiverAddress'),
             receiverJibunAddress: 'asf',
             receiverDetailAddress: getValues(
@@ -420,22 +445,6 @@ const Sheet = () => {
             },
         },
     );
-
-    const orderPriceData = orderData?.data.paymentInfo && [
-        ['총 주문금액', orderData.data.paymentInfo.totalStandardAmt],
-        ['총 배송비', orderData.data.paymentInfo.deliveryAmt],
-        [
-            '총 할인금액',
-            orderData.data.paymentInfo.totalImmediateDiscountAmt +
-                orderData.data.paymentInfo.totalAdditionalDiscountAmt,
-        ],
-        [
-            '쿠폰 할인',
-            orderData.data.paymentInfo.cartCouponAmt +
-                +orderData.data.paymentInfo.productCouponAmt +
-                orderData.data.paymentInfo.deliveryCouponAmt,
-        ],
-    ];
 
     const orderTerms = [
         'agreeOrderService',

--- a/src/pages/Order/Sheet.tsx
+++ b/src/pages/Order/Sheet.tsx
@@ -29,6 +29,7 @@ import CouponListModal from 'components/Modal/CouponListModal';
 import { ReactComponent as Checked } from 'assets/icons/checkbox_square_checked.svg';
 import { ReactComponent as UnChecked } from 'assets/icons/checkbox_square_unchecked.svg';
 import { tokenStorage } from 'utils/storage';
+import { OrderPrice } from 'pages/Cart/Cart';
 
 const accessTokenInfo = tokenStorage.getAccessToken();
 
@@ -285,8 +286,7 @@ const Sheet = () => {
         >
     >([]);
     const [ordererInformation, setOrdererInformation] = useState(false);
-    const [orderPriceData, setOrderPriceData] =
-        useState<{ name: string; price: number }[]>();
+    const [orderPriceData, setOrderPriceData] = useState<OrderPrice>({});
     const [agreePurchase, setAgreePurchase] = useState<string[]>([]);
     const [isShippingListModal, setIsShippingListModal] = useState(false);
     const [isSearchAddressModal, setIsSearchAddressModal] = useState(false);
@@ -347,29 +347,31 @@ const Sheet = () => {
                     });
                     return [...newOrderList];
                 });
-                setOrderPriceData([
-                    {
+                setOrderPriceData((prev) => {
+                    prev.totalOrderPrice = {
                         name: '총 주문금액',
                         price: res?.data.paymentInfo.totalStandardAmt,
-                    },
-                    {
+                    };
+                    prev.totalDeliveryPrice = {
                         name: '총 배송비',
                         price: res?.data.paymentInfo.deliveryAmt,
-                    },
-                    {
+                    };
+                    prev.totalDiscountPrice = {
                         name: '총 할인금액',
                         price:
                             res?.data.paymentInfo.totalImmediateDiscountAmt +
                             res?.data.paymentInfo.totalAdditionalDiscountAmt,
-                    },
-                    {
-                        name: '쿠폰 할인',
-                        price:
-                            res?.data.paymentInfo.cartCouponAmt +
-                            +res?.data.paymentInfo.productCouponAmt +
-                            res?.data.paymentInfo.deliveryCouponAmt,
-                    },
-                ]);
+                    };
+                    if (member)
+                        prev.couponDiscount = {
+                            name: '쿠폰 할인',
+                            price:
+                                res?.data.paymentInfo.cartCouponAmt +
+                                +res?.data.paymentInfo.productCouponAmt +
+                                res?.data.paymentInfo.deliveryCouponAmt,
+                        };
+                    return { ...prev };
+                });
             },
             refetchOnWindowFocus: false,
         },
@@ -633,11 +635,7 @@ const Sheet = () => {
                     <SheetOrderPriceWrapper id='SendPayForm_id' method='POST'>
                         <OrderSheetPrice
                             title='총 결제 금액'
-                            cartOrderPrice={
-                                member
-                                    ? orderPriceData
-                                    : orderPriceData?.slice(0, 3)
-                            }
+                            cartOrderPrice={orderPriceData}
                             amountPrice={orderData?.data.paymentInfo.paymentAmt}
                         />
                         <AgreeButton>

--- a/src/pages/Product/ProductDetail.tsx
+++ b/src/pages/Product/ProductDetail.tsx
@@ -155,6 +155,7 @@ const BuyNow = styled.div`
     color: #fff;
     font-weight: bold;
     font-size: 24px;
+    cursor: pointer;
     > span {
         vertical-align: middle;
     }
@@ -244,7 +245,10 @@ const ProductDetail = () => {
     );
 
     const addCartHandler = () => {
-        if (selectOptionProducts.size <= 0) return;
+        if (selectOptionProducts.size <= 0) {
+            alert('옵션을 선택해주세요.');
+            return;
+        }
 
         const cartList: ShoppingCartBody[] = [];
         if (!member) {
@@ -294,6 +298,7 @@ const ProductDetail = () => {
 
     const purchaseHandler = () => {
         if (selectOptionProducts.size <= 0) {
+            alert('옵션을 선택해주세요.');
             return;
         }
 


### PR DESCRIPTION
Desc
- 상품 상세 페이지 옵션 선택 없이 구매하기 및 장바구니 버튼 클릭시 alert '옵션을 선택해주세요.'
- 장바구니 페이지 비회원 주문서 부분 선택한 상품의 금액만 표시
- 장바구니 상품 체크시 깜빡임 수정
- 장바구니 상품 체크 이후 개수 수정시 주문서에 0원으로 출력되는 오류 수정