### PR TITLE
feat: 골프 코스 요청 페이지(GolfCourseRequest) 작성

### DIFF
--- a/src/assets/icons/arrow_right_small.svg
+++ b/src/assets/icons/arrow_right_small.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="5.089" height="7.753" viewBox="0 0 5.089 7.753">
+  <g id="그룹_1187" data-name="그룹 1187" transform="translate(0.329 0.376)">
+    <path id="패스_15" data-name="패스 15" d="M0,0,4,3.5,0,7" fill="none" stroke="#999" stroke-width="1"/>
+  </g>
+</svg>

--- a/src/components/Common/SelectBox.tsx
+++ b/src/components/Common/SelectBox.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import Select, { SingleValue, ActionMeta, StylesConfig } from 'react-select';
 
 import { ReactComponent as DropDownIcon } from 'assets/icons/arrow_drop_down.svg';
@@ -67,6 +68,7 @@ export const customStyle = {
         color: '#a8a8a8',
         fontSize: '16px',
         fontFamily: 'Noto Sans CJK KR',
+        marginTop: '4px',
     }),
     indicatorsContainer: (provided: any) => ({
         ...provided,
@@ -75,33 +77,42 @@ export const customStyle = {
     indicatorSeparator: () => ({}),
 };
 
-const SelectBox = <T extends any>({
+const SelectBox = forwardRef(
+    <T extends any>({
+        options,
+        onChange,
+        styles,
+        placeHolder,
+        defaultValue,
+        isDisabled,
+    }: SelectBoxProps<T>) => {
+        const DropdownIndicator = () => {
+            return <DropDownIcon />;
+        };
+
+        return (
+            <Select
+                defaultValue={defaultValue}
+                options={options}
+                onChange={onChange}
+                placeholder={placeHolder}
+                styles={
+                    styles
+                        ? styles
+                        : (customStyle as StylesConfig<Partial<T>, false>)
+                }
+                isDisabled={isDisabled}
+                components={{ DropdownIndicator }}
+            />
+        );
+    },
+);
+
+export default SelectBox as <T extends any>({
     options,
     onChange,
     styles,
     placeHolder,
     defaultValue,
     isDisabled,
-}: SelectBoxProps<T>) => {
-    const DropdownIndicator = () => {
-        return <DropDownIcon />;
-    };
-
-    return (
-        <Select
-            defaultValue={defaultValue}
-            options={options}
-            onChange={onChange}
-            placeholder={placeHolder}
-            styles={
-                styles
-                    ? styles
-                    : (customStyle as StylesConfig<Partial<T>, false>)
-            }
-            isDisabled={isDisabled}
-            components={{ DropdownIndicator }}
-        />
-    );
-};
-
-export default SelectBox;
+}: SelectBoxProps<T>) => JSX.Element;

--- a/src/components/GolfCourse/RequestResultProgress.tsx
+++ b/src/components/GolfCourse/RequestResultProgress.tsx
@@ -1,0 +1,85 @@
+import styled from 'styled-components';
+
+import media from 'utils/styles/media';
+
+const RequestResultProgressContainer = styled.ul`
+    width: 100%;
+    background: ${(props) => props.theme.bg2};
+    padding: 19px 0;
+    display: flex;
+    justify-content: space-between;
+    letter-spacing: 0;
+`;
+
+const RequestResultProgress = styled.li`
+    border-right: ${(props) => `1px dashed ${props.theme.line2}`};
+    width: 33.333%;
+    padding: 8px 0;
+    &:last-child {
+        border-right: none;
+    }
+`;
+
+const RequestResultStatus = styled.p`
+    color: #999;
+    font-size: 0.75rem;
+    margin-bottom: 10px;
+    ${media.xlarge} {
+        font-size: 0.857rem;
+    }
+    ${media.medium} {
+        font-size: 1rem;
+    }
+`;
+
+const RequestResultCount = styled.p`
+    font-size: 1.5rem;
+    font-weight: 500;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    ${media.medium} {
+        font-size: 1.666rem;
+    }
+    > span {
+        font-weight: 400;
+        margin-left: 8px;
+        color: ${(props) => props.theme.text3};
+        font-size: 0.75rem;
+        ${media.xlarge} {
+            font-size: 0.857rem;
+        }
+        ${media.medium} {
+            font-size: 1rem;
+        }
+    }
+`;
+
+interface RequestProgress {
+    status: string;
+    count: number | string;
+}
+
+const RequestResult = ({
+    requestProgressData,
+}: {
+    requestProgressData?: Array<RequestProgress>;
+}) => {
+    return (
+        <RequestResultProgressContainer>
+            {requestProgressData?.map(({ status, count }) => {
+                return (
+                    <RequestResultProgress>
+                        <RequestResultStatus>{status}</RequestResultStatus>
+                        <RequestResultCount>
+                            {count}
+                            <span>건</span>
+                        </RequestResultCount>
+                    </RequestResultProgress>
+                );
+            })}
+        </RequestResultProgressContainer>
+    );
+};
+
+export default RequestResult;

--- a/src/models/member/index.ts
+++ b/src/models/member/index.ts
@@ -129,3 +129,66 @@ export interface UpdatePasswordParams {
     key: string;
     certificationNumber: string;
 }
+export interface ProfileResponse {
+    mallName: string;
+    memberNo: number;
+    memberGradeName: string;
+    memberGroupNames: string;
+    memberGroups: MemberGroup[];
+    memberName: string;
+    memberId: string;
+    mobileNo: string;
+    telephoneNo: string;
+    memberStatus: string;
+    memberType: string;
+    principalCertificated: boolean;
+    certificationType: any;
+    birthday: string;
+    sex: string;
+    email: string;
+    zipCd: string;
+    address: string;
+    detailAddress: string;
+    jibunAddress: string;
+    jibunDetailAddress: string;
+    nickname: string;
+    joinTypeName: string;
+    joinYmdt: string;
+    lastLoginYmdt: string;
+    lastLoginIp: string;
+    loginCount: number;
+    pushNotificationAgreed: boolean;
+    pushNotificationAgreeYmdt: string;
+    pushNotificationDisagreeYmdt: any;
+    smsAgreed: boolean;
+    smsAgreeYmdt: string;
+    smsDisagreeYmdt: any;
+    directMailAgreed: boolean;
+    directMailAgreeYmdt: string;
+    directMailDisagreeYmdt: any;
+    countryCd: string;
+    oauthIdNo: string;
+    additionalInfo: string;
+    adultCertificated: boolean;
+    adultCertificatedYmdt: string;
+    refundBank: string;
+    refundBankAccount: string;
+    refundBankDepositorName: string;
+    agreedTerms: string[];
+    agreedTermsInfos: AgreedTermsInfo[];
+    providerType: string;
+    providerTypes: string[];
+    businessName: any;
+    registrationNo: any;
+}
+
+export interface MemberGroup {
+    memberGroupNo: number;
+    memberGroupName: string;
+    memberGroupDescription: string;
+}
+
+export interface AgreedTermsInfo {
+    termsType: string;
+    agreementYmdt: string;
+}

--- a/src/pages/GolfCourse/GolfCourseRequest.tsx
+++ b/src/pages/GolfCourse/GolfCourseRequest.tsx
@@ -673,6 +673,7 @@ const GolfCourseRequest = () => {
                                             accept='.bmp, .tif, .tiff, .miff, .gif, .jpe, .jpeg, .jpg, .jps, .pjpeg, .jng, .mng, .png'
                                             onChange={(e) => {
                                                 if (e.target.files) {
+                                                    setImageName((prev) => {
                                                         return {
                                                             ...prev,
                                                             courseLayoutImageName:

--- a/src/pages/GolfCourse/GolfCourseRequest.tsx
+++ b/src/pages/GolfCourse/GolfCourseRequest.tsx
@@ -1,7 +1,721 @@
-import React from 'react';
+import { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { StylesConfig } from 'react-select';
+import { shallowEqual } from 'react-redux';
+import { useWindowSize } from 'usehooks-ts';
+import { ErrorMessage } from '@hookform/error-message';
+import { useForm } from 'react-hook-form';
+import { head } from '@fxts/core';
+
+import LayoutResponsive from 'components/shared/LayoutResponsive';
+import RequestResultProgress from 'components/GolfCourse/RequestResultProgress';
+import SelectBox, { customStyle } from 'components/Common/SelectBox';
+import Header from 'components/shared/Header';
+import MobileHeader from 'components/shared/MobileHeader';
+import SEOHelmet from 'components/shared/SEOHelmet';
+import StyledErrorMessage from 'components/Common/StyledErrorMessage';
+import { ReactComponent as ArrowRight } from 'assets/icons/arrow_right_small.svg';
+import { ReactComponent as Checked } from 'assets/icons/checkbox_square_checked.svg';
+import { ReactComponent as UnChecked } from 'assets/icons/checkbox_square_unchecked.svg';
+import { useTypedSelector } from 'state/reducers';
+import PATHS from 'const/paths';
+import { countries } from 'const/country';
+import { isDesktop, isMobile } from 'utils/styles/responsive';
+import media from 'utils/styles/media';
+
+const CourseRequestContainer = styled(LayoutResponsive)`
+    width: 840px;
+    ${media.custom(888)} {
+        width: 100%;
+        padding: 49px 24px;
+    }
+`;
+
+const RequestResultContainer = styled.section`
+    width: 100%;
+    margin-bottom: 41px;
+`;
+
+const RequestResultTitle = styled.h3`
+    font-size: 1.5rem;
+    letter-spacing: -1.2px;
+    font-weight: bold;
+    margin-bottom: 12px;
+    text-align: left;
+    ${media.custom(1280)} {
+        font-size: 1.428rem;
+        letter-spacing: -1px;
+    }
+    ${media.medium} {
+        font-size: 1.666rem;
+    }
+`;
+
+const GoRequestListButton = styled(Link)`
+    display: flex;
+    align-items: center;
+    justify-content: right;
+    font-size: 0.75rem;
+    letter-spacing: 0;
+    color: #999;
+    margin-bottom: 11px;
+    > svg {
+        margin-left: 10px;
+    }
+    ${media.xlarge} {
+        font-size: 0.857rem;
+    }
+    ${media.medium} {
+        font-size: 1rem;
+    }
+`;
+
+const CourseRequestBottom = styled.section`
+    width: 440px;
+    margin: 0 auto;
+    ${media.custom(488)} {
+        width: 100%;
+        padding: 0 24px;
+    }
+`;
+
+const CourseRequestTitle = styled.h2`
+    color: ${(props) => props.theme.text1};
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 22px;
+`;
+
+const CourseRequestDescription = styled.p`
+    color: #767676;
+    margin-bottom: 30px;
+    line-height: 1.3;
+    ${media.medium} {
+        font-size: 1.166rem;
+        margin-bottom: 20px;
+    }
+`;
+
+const CourseRequestForm = styled.form`
+    padding-top: 10px;
+    margin-bottom: 32px;
+    width: 100%;
+    border-top: ${(props) => `2px solid ${props.theme.secondary}`};
+    border-bottom: ${(props) => `1px solid ${props.theme.secondary}`};
+`;
+
+const RequestInformationContainer = styled.div`
+    color: ${(props) => props.theme.text1};
+    border-bottom: ${(props) => `1px solid ${props.theme.line2}`};
+    padding: 20px 0 20px;
+    &:last-child {
+        border-bottom: none;
+    }
+`;
+
+const CourseRequestSubTitle = styled.p`
+    text-align: left;
+    font-weight: 500;
+    letter-spacing: 0px;
+    margin-bottom: 30px;
+    ${media.xlarge} {
+        font-size: 1.142rem;
+    }
+    ${media.medium} {
+        letter-spacing: 0.8px;
+        font-weight: bold;
+        font-size: 1.333rem;
+        margin-bottom: 22px;
+    }
+`;
+
+const CourseRequestInputContainer = styled.div`
+    margin-bottom: 21px;
+    > &:last-child {
+        margin-bottom: 0;
+    }
+    div {
+        text-align: left;
+        font-size: 1rem;
+        ${media.xlarge} {
+            font-size: 1.142rem;
+        }
+        ${media.medium} {
+            font-size: 1.333rem;
+        }
+    }
+`;
+
+const CourseRequestInputTitle = styled.p`
+    display: flex;
+    align-items: center;
+    font-size: 0.75rem;
+    margin-bottom: 14px;
+    text-align: left;
+    font-weight: 500;
+    ${media.xlarge} {
+        font-size: 1rem;
+    }
+    ${media.medium} {
+        font-size: 1.333rem;
+        margin-bottom: 11px;
+    }
+`;
+
+const RequireIcon = styled.span`
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: ${(props) => props.theme.primary};
+    margin-left: 10px;
+`;
+
+const CourseRequestInput = styled.input`
+    width: 100%;
+    padding: 9px 21px;
+    border: ${(props) => `1px solid ${props.theme.line2}`};
+    font-size: 1rem;
+    &::placeholder {
+        color: ${(props) => props.theme.text3};
+    }
+    &:focus {
+        border: ${(props) => `1px solid ${props.theme.primary}`};
+    }
+    ${media.xlarge} {
+        font-size: 1.142rem;
+    }
+    ${media.medium} {
+        font-size: 1.333rem;
+        padding: 14px 21px;
+    }
+`;
+
+const CourseRequestTextArea = styled(CourseRequestInput)`
+    min-height: 132px;
+`;
+
+const CourseRequestImageFileContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    height: 44px;
+    > label {
+        color: #fff;
+        background: ${(props) => props.theme.secondary};
+        text-align: center;
+        line-height: 44px;
+        width: 23.18%;
+        cursor: pointer;
+        > input {
+            display: none;
+        }
+    }
+    ${media.medium} {
+        height: 54px;
+        > label {
+            line-height: 54px;
+        }
+    }
+`;
+
+const CourseRequestImageTitle = styled(CourseRequestInput)`
+    color: ${(props) => props.theme.text1};
+    width: 75%;
+    background: ${(props) => props.theme.bg2};
+    border: none;
+`;
+
+const AgreeTermContainer = styled.div`
+    margin-bottom: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    > div {
+        > label {
+            display: flex;
+            align-items: center;
+            > p {
+                margin-left: 10px;
+            }
+        }
+        > input {
+            display: none;
+        }
+    }
+    > a {
+        font-size: 10px;
+        letter-spacing: 0;
+        color: #bcbcbc;
+        text-decoration: underline;
+    }
+`;
+
+const CourseRequestButton = styled.button`
+    color: #fff;
+    background: ${(props) => props.theme.secondary};
+    text-align: center;
+    line-height: 44px;
+    width: 100%;
+    font-size: 1rem;
+    ${media.xlarge} {
+        font-size: 1.142rem;
+    }
+    ${media.medium} {
+        font-size: 1.333rem;
+    }
+`;
+
+const dummyRequestProgressData = [
+    { status: '대기', count: '2' },
+    { status: '취소', count: '1' },
+    { status: '완료', count: '20' },
+];
+
+const dummyRequestCategory = [
+    '골프장 정보 추가 및 업데이트',
+    '고도 정보 추가 및 업데이트',
+    '그린뷰 정보 추가 및 업데이트',
+    '코스뷰 정보 추가 및 업데이트',
+];
+
+interface CourseRequestBody {
+    userEmail: string;
+    userName: string;
+    country: string;
+    region?: string;
+    golfCourseName?: string;
+    requestCategory: string;
+    requestDetail: string;
+    productName: string;
+    scoreImageUrl?: string;
+    courseLayoutImageUrl?: string;
+}
 
 const GolfCourseRequest = () => {
-    return <div>GolfCourseRequest</div>;
+    const [isAgreeTerm, setIsAgreeTerm] = useState(false);
+
+    const [imageName, setImageName] = useState<{
+        scoreImageName?: string;
+        courseLayoutImageName?: string;
+    }>({});
+
+    const { member } = useTypedSelector(
+        ({ member }) => ({
+            member: member.data,
+        }),
+        shallowEqual,
+    );
+
+    const {
+        register,
+        handleSubmit,
+        setValue,
+        formState: { errors },
+    } = useForm<CourseRequestBody>({
+        defaultValues: {
+            userEmail: member?.email,
+            userName: member?.memberName,
+        },
+    });
+
+    const { width } = useWindowSize();
+
+    const requestSelectStyle = useMemo(() => {
+        return {
+            control: (
+                provided: any,
+                { menuIsOpen }: { menuIsOpen: boolean },
+            ) => ({
+                boxSizing: 'border-box',
+                width: '100%',
+                border: '1px solid #DBDBDB',
+                borderBottom: menuIsOpen ? 'none' : '',
+                display: 'flex',
+                height: isMobile(width) ? '54px' : '44px',
+                background: '#fff',
+                paddingLeft: '12px',
+            }),
+            option: () => ({
+                height: isMobile(width) ? '54px' : '44px',
+                lineHeight: isMobile(width) ? '12px' : '4px',
+                width: '100%',
+                boxSizing: 'border-box',
+                border: '1px solid #DBDBDB',
+                background: '#fff',
+                padding: '20px',
+                paddingLeft: '21px',
+                color: '#191919',
+                cursor: 'pointer',
+                fontWeight: 'normal',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                '&:hover': {
+                    borderLeft: '2px solid #c00020',
+                    background: '#F0EFF4',
+                    fontWeight: 'bold',
+                },
+            }),
+        };
+    }, [width]);
+
+    const onSubmit = handleSubmit(() => {
+        if (!isAgreeTerm) {
+            alert('약관에 동의해주세요');
+            return;
+        }
+        // TODO 요청완료시 alert “골프장코스요청이완료되었습니다.신속하게반영될수있도록노력하겠습니다."
+    });
+
+    return (
+        <>
+            {isDesktop(width) ? (
+                <Header />
+            ) : (
+                <MobileHeader title={'코스 요청하기'} />
+            )}
+            <SEOHelmet
+                data={{
+                    title: '보이스캐디 코스 요청',
+                    meta: {
+                        title: '보이스캐디 코스 요청',
+                        description: '보이스캐디 코스 요청하기',
+                    },
+                    og: {
+                        title: '보이스캐디 코스 요청',
+                        description: '보이스캐디 코스 요청하기',
+                    },
+                }}
+            />
+            <CourseRequestContainer>
+                <RequestResultContainer>
+                    <RequestResultTitle>나의 요청 결과</RequestResultTitle>
+                    <GoRequestListButton to={PATHS.GOLF_COURSE_LIST}>
+                        자세히 <ArrowRight />
+                    </GoRequestListButton>
+                    <RequestResultProgress
+                        requestProgressData={dummyRequestProgressData}
+                    />
+                </RequestResultContainer>
+                <CourseRequestBottom>
+                    <CourseRequestTitle>코스 요청하기</CourseRequestTitle>
+                    <CourseRequestDescription>
+                        필요한 골프장 정보를 입력해주세요.
+                        <br />
+                        신속하게 반영될 수 있도록 노력하겠습니다.
+                    </CourseRequestDescription>
+                    <CourseRequestForm>
+                        <RequestInformationContainer>
+                            <CourseRequestSubTitle>
+                                요청자 정보
+                            </CourseRequestSubTitle>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    이메일
+                                    <RequireIcon />
+                                </CourseRequestInputTitle>
+                                <CourseRequestInput
+                                    type={'email'}
+                                    placeholder='이메일을 입력해주세요.'
+                                    {...register('userEmail', {
+                                        required: {
+                                            value: true,
+                                            message: '이메일을 입력해주세요',
+                                        },
+                                    })}
+                                />
+                                <ErrorMessage
+                                    errors={errors}
+                                    name='userEmail'
+                                    render={({ message }) => (
+                                        <StyledErrorMessage>
+                                            {message}
+                                        </StyledErrorMessage>
+                                    )}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    이름
+                                    <RequireIcon />
+                                </CourseRequestInputTitle>
+                                <CourseRequestInput
+                                    type={'text'}
+                                    placeholder='이름을 입력해주세요.'
+                                    {...register('userName', {
+                                        required: {
+                                            value: true,
+                                            message: '이름을 입력해주세요',
+                                        },
+                                    })}
+                                />
+                                <ErrorMessage
+                                    errors={errors}
+                                    name='userName'
+                                    render={({ message }) => (
+                                        <StyledErrorMessage>
+                                            {message}
+                                        </StyledErrorMessage>
+                                    )}
+                                />
+                            </CourseRequestInputContainer>
+                        </RequestInformationContainer>
+
+                        <RequestInformationContainer>
+                            <CourseRequestSubTitle>
+                                골프장 요청 정보
+                            </CourseRequestSubTitle>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    국가
+                                    <RequireIcon />
+                                </CourseRequestInputTitle>
+                                <SelectBox<any>
+                                    styles={{
+                                        ...(customStyle as StylesConfig<
+                                            Partial<any>,
+                                            false
+                                        >),
+                                        ...(requestSelectStyle as StylesConfig<
+                                            Partial<any>,
+                                            false
+                                        >),
+                                    }}
+                                    options={countries.map((country) => {
+                                        return {
+                                            label: country,
+                                            value: country,
+                                        };
+                                    })}
+                                    {...register('country', {
+                                        required: {
+                                            value: true,
+                                            message: '국가를 선택해주세요',
+                                        },
+                                    })}
+                                    onChange={(e) => {
+                                        setValue('country', e?.value);
+                                    }}
+                                    placeHolder='국가를 선택해주세요.'
+                                />
+                                <ErrorMessage
+                                    errors={errors}
+                                    name='country'
+                                    render={({ message }) => (
+                                        <StyledErrorMessage>
+                                            {message}
+                                        </StyledErrorMessage>
+                                    )}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    지역
+                                </CourseRequestInputTitle>
+                                <CourseRequestInput
+                                    type={'text'}
+                                    {...register('region')}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    골프장명
+                                </CourseRequestInputTitle>
+                                <CourseRequestInput
+                                    type={'text'}
+                                    {...register('golfCourseName')}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    요청항목
+                                    <RequireIcon />
+                                </CourseRequestInputTitle>
+                                <SelectBox
+                                    styles={{
+                                        ...(customStyle as StylesConfig<
+                                            Partial<any>,
+                                            false
+                                        >),
+                                        ...(requestSelectStyle as StylesConfig<
+                                            Partial<any>,
+                                            false
+                                        >),
+                                    }}
+                                    options={dummyRequestCategory.map(
+                                        (category) => {
+                                            return {
+                                                label: category,
+                                                value: category,
+                                            };
+                                        },
+                                    )}
+                                    {...register('requestCategory', {
+                                        required: {
+                                            value: true,
+                                            message: '요청 항목을 선택해주세요',
+                                        },
+                                    })}
+                                    onChange={(e) => {
+                                        setValue('requestCategory', e?.value);
+                                    }}
+                                    placeHolder='요청 항목을 선택해주세요.'
+                                />
+                                <ErrorMessage
+                                    errors={errors}
+                                    name='requestCategory'
+                                    render={({ message }) => (
+                                        <StyledErrorMessage>
+                                            {message}
+                                        </StyledErrorMessage>
+                                    )}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    세부내용
+                                    <RequireIcon />
+                                </CourseRequestInputTitle>
+                                <CourseRequestTextArea
+                                    as={'textarea'}
+                                    {...register('requestDetail', {
+                                        required: {
+                                            value: true,
+                                            message: '세부내용을 입력해주세요',
+                                        },
+                                    })}
+                                    placeholder='요청사항을 적어주세요.'
+                                />
+                                <ErrorMessage
+                                    errors={errors}
+                                    name='requestDetail'
+                                    render={({ message }) => (
+                                        <StyledErrorMessage>
+                                            {message}
+                                        </StyledErrorMessage>
+                                    )}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    사용제품
+                                    <RequireIcon />
+                                </CourseRequestInputTitle>
+                                <CourseRequestInput
+                                    type={'text'}
+                                    {...register('productName', {
+                                        required: {
+                                            value: true,
+                                            message: '사용제품을 입력해주세요',
+                                        },
+                                    })}
+                                />
+                                <ErrorMessage
+                                    errors={errors}
+                                    name='productName'
+                                    render={({ message }) => (
+                                        <StyledErrorMessage>
+                                            {message}
+                                        </StyledErrorMessage>
+                                    )}
+                                />
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    스코어카드 이미지
+                                </CourseRequestInputTitle>
+                                <CourseRequestImageFileContainer>
+                                    <CourseRequestImageTitle
+                                        placeholder='파일을 선택해주세요'
+                                        type='text'
+                                        disabled
+                                        value={imageName.scoreImageName}
+                                    />
+                                    <label htmlFor='scoreCard'>
+                                        <input
+                                            type='file'
+                                            id='scoreCard'
+                                            accept='.bmp, .tif, .tiff, .miff, .gif, .jpe, .jpeg, .jpg, .jps, .pjpeg, .jng, .mng, .png'
+                                            onChange={(e) => {
+                                                if (e.target.files) {
+                                                    setImageName((prev) => {
+                                                        return {
+                                                            ...prev,
+                                                            scoreImageName:
+                                                                head(
+                                                                    e.target
+                                                                        .files!,
+                                                                )?.name,
+                                                        };
+                                                    });
+                                                }
+                                            }}
+                                        />
+                                        파일 선택
+                                    </label>
+                                </CourseRequestImageFileContainer>
+                            </CourseRequestInputContainer>
+                            <CourseRequestInputContainer>
+                                <CourseRequestInputTitle>
+                                    코스 레이아웃 이미지
+                                </CourseRequestInputTitle>
+                                <CourseRequestImageFileContainer>
+                                    <CourseRequestImageTitle
+                                        placeholder='파일을 선택해주세요'
+                                        type='text'
+                                        disabled
+                                        value={imageName.courseLayoutImageName}
+                                    />
+                                    <label htmlFor='courseLayout'>
+                                        <input
+                                            type='file'
+                                            id='courseLayout'
+                                            accept='.bmp, .tif, .tiff, .miff, .gif, .jpe, .jpeg, .jpg, .jps, .pjpeg, .jng, .mng, .png'
+                                            onChange={(e) => {
+                                                if (e.target.files) {
+                                                        return {
+                                                            ...prev,
+                                                            courseLayoutImageName:
+                                                                head(
+                                                                    e.target
+                                                                        .files!,
+                                                                )?.name,
+                                                        };
+                                                    });
+                                                }
+                                            }}
+                                        />
+                                        파일 선택
+                                    </label>
+                                </CourseRequestImageFileContainer>
+                            </CourseRequestInputContainer>
+                        </RequestInformationContainer>
+                    </CourseRequestForm>
+                    <AgreeTermContainer>
+                        <div>
+                            <input
+                                type='checkbox'
+                                id='agreeRequestTerm'
+                                onChange={() => setIsAgreeTerm(!isAgreeTerm)}
+                                checked={isAgreeTerm}
+                            />
+                            <label htmlFor='agreeRequestTerm'>
+                                {isAgreeTerm ? <Checked /> : <UnChecked />}
+                                <p>
+                                    개인정보수집에 대한 내용을 읽었으며,
+                                    동의합니다.
+                                </p>
+                            </label>
+                        </div>
+                        <Link to={PATHS.MAIN}>자세히보기</Link>
+                    </AgreeTermContainer>
+                    <CourseRequestButton onClick={() => onSubmit()}>
+                        골프 코스 요청하기
+                    </CourseRequestButton>
+                </CourseRequestBottom>
+            </CourseRequestContainer>
+        </>
+    );
 };
 
 export default GolfCourseRequest;

--- a/src/state/slices/memberSlice.ts
+++ b/src/state/slices/memberSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { profile } from 'api/member';
-import { ProfileBody } from 'models/member';
+import { ProfileResponse } from 'models/member';
 
 export const fetchProfile = createAsyncThunk('member/profile', async () => {
     try {
@@ -13,7 +13,7 @@ export const fetchProfile = createAsyncThunk('member/profile', async () => {
 
 const memberInitialState: {
     loading: boolean;
-    data: Nullable<ProfileBody>;
+    data: Nullable<ProfileResponse>;
     error: any;
 } = {
     loading: false,


### PR DESCRIPTION
- GolfCourseRequest 페이지 작성
    - 로그인 한 유저일 경우 이름 및 이메일 기본값 노출
    - 반응형 디자인 적용
    - 진행 상태 컴포넌트는 dummy 데이터 사용중
- 코스 요청 진행 상태 (RequestResultProgress) 컴포넌트 작성
- SelectBox에 forwardRef 적용
- profile response 타입 (member.data) 작성 및 적용
- 다국어 처리 아직 작성 안함